### PR TITLE
Add OpenMP directive IR printing and roundtrip tests

### DIFF
--- a/tests/openmp_roundtrip.rs
+++ b/tests/openmp_roundtrip.rs
@@ -1,0 +1,51 @@
+use roup::parser::{openmp, ClauseRule, Parser};
+
+fn parse(input: &str) -> roup::parser::Directive<'_> {
+    let parser = Parser::default();
+    let (_, directive) = parser.parse(input).expect("directive should parse");
+    directive
+}
+
+#[test]
+fn roundtrips_all_openmp_directives_without_clauses() {
+    for directive in openmp::OpenMpDirective::ALL {
+        let source = format!("#pragma omp {}", directive.as_str());
+        let parsed = parse(&source);
+        assert_eq!(
+            parsed.to_pragma_string(),
+            source,
+            "directive: {}",
+            directive.as_str()
+        );
+    }
+}
+
+fn sample_clause(clause: openmp::OpenMpClause) -> Option<String> {
+    match clause.rule() {
+        ClauseRule::Bare => Some(clause.name().to_string()),
+        ClauseRule::Parenthesized | ClauseRule::Flexible => {
+            Some(format!("{}(value)", clause.name()))
+        }
+        ClauseRule::Custom(_) => Some(format!("{}(value)", clause.name())),
+        ClauseRule::Unsupported => None,
+    }
+}
+
+#[test]
+fn roundtrips_all_openmp_clauses() {
+    for clause in openmp::OpenMpClause::ALL {
+        let Some(clause_source) = sample_clause(*clause) else {
+            continue;
+        };
+
+        let source = format!("#pragma omp parallel {}", clause_source);
+        let parsed = parse(&source);
+
+        assert_eq!(
+            parsed.to_pragma_string(),
+            source,
+            "clause: {}",
+            clause.name()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- implement display support for clauses and directives, providing a reusable `to_pragma_string` helper
- add focused unit tests plus end-to-end roundtrip coverage for every registered OpenMP directive and clause

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e8ad40d844832fbecf1b46562b09bb