### PR TITLE
Support OpenMP line continuations across languages

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -19,6 +19,7 @@
 
 - [API Reference](./api-reference.md)
 - [OpenMP Support Matrix](./openmp-support.md)
+- [OpenMP Line Continuations](./line-continuations.md)
 
 # Developer Guide
 

--- a/docs/book/src/fortran-tutorial.md
+++ b/docs/book/src/fortran-tutorial.md
@@ -301,27 +301,18 @@ my_program: my_program.f90
 	$(FC) -o $@ $< $(ROUP_LIB)
 ```
 
+## Multi-line Directives
+
+ROUP now accepts multi-line OpenMP directives in both free-form and fixed-form Fortran. The parser understands trailing `&`, optional leading `&` on continuation lines, and repeated sentinels such as `!$OMP` or `C$OMP`. For a deep dive—including C and C++ examples—see [OpenMP Line Continuations](./line-continuations.md).
+
 ## Known Limitations
 
 ⚠️ **Current limitations in experimental Fortran support:**
 
-1. **Single-Line Input Only**: ROUP requires complete directives on a single line
-   - **Not supported**: Multi-line directives with `&` continuation
-     ```fortran
-     !$OMP PARALLEL DO &
-     !$OMP   PRIVATE(I,J)
-     ```
-   - **Workaround**: Provide complete directive on one line:
-     ```fortran
-     !$OMP PARALLEL DO PRIVATE(I,J)
-     ```
-   - **Rationale**: This is an architectural design constraint that applies to both C and Fortran. Users must preprocess multi-line directives into single lines before passing to ROUP.
-
-2. **End Directives**: `!$OMP END PARALLEL` and similar end directives may not parse correctly
-
-3. **Array Sections**: Complex array section syntax may have issues
-4. **Fixed-Form Column Rules**: Strict column 1-6 sentinel placement not enforced
-5. **Fortran-Specific Directives**: Some Fortran-only directives (e.g., `WORKSHARE`) may not be registered
+1. **End Directives**: `!$OMP END PARALLEL` and similar end directives may not parse correctly
+2. **Array Sections**: Complex array section syntax may have issues
+3. **Fixed-Form Column Rules**: Strict column 1-6 sentinel placement not enforced
+4. **Fortran-Specific Directives**: Some Fortran-only directives (e.g., `WORKSHARE`) may not be registered
 
 ## Troubleshooting
 

--- a/docs/book/src/line-continuations.md
+++ b/docs/book/src/line-continuations.md
@@ -1,0 +1,81 @@
+# OpenMP Line Continuations
+
+⚠️ **Experimental**: Continuation support is part of ROUP's evolving parser pipeline. The behaviour described here applies to the current working prototype and may change as the project matures.
+
+OpenMP directives frequently span multiple source lines, either for readability or to respect column limits in Fortran. ROUP normalises these layouts before parsing so that callers can feed directives exactly as they appear in their source files. The normalisation happens inside the lexer and therefore works uniformly for the Rust API, the C API, and the ompparser compatibility layer.
+
+## Supported Patterns
+
+ROUP recognises three families of continuation syntax:
+
+1. **C/C++ backslash-newline** – the standard preprocessor line continuation.
+2. **Fortran free-form ampersand** – trailing `&` on a line, with an optional leading `&` on the continuation line.
+3. **Fortran fixed-form sentinels** – repeated `!$OMP`, `C$OMP`, or `*$OMP` with an optional column-6 `&`.
+
+Whitespace, comments, and Windows-style newlines (`\r\n`) are preserved for readability but ignored by the parser when they appear in continuation positions.
+
+## C / C++ Example
+
+```c
+#pragma omp target \
+    // Comments and indentation are fine
+    map(to: a[0:N]) \
+    map(from: b[0:N])
+```
+
+Key points:
+
+- Every backslash must be the last non-whitespace character on the line.
+- Line-local comments (`//` or `/* ... */`) between continued lines are ignored.
+- After normalisation, the parser sees a single logical directive equivalent to `#pragma omp target map(to: ...) map(from: ...)`.
+
+## Fortran Free-Form Examples
+
+```fortran
+!$omp parallel do &
+  private(i, j) &
+& schedule(static)
+```
+
+```fortran
+!$omp target teams distribute &
+!$omp& map(to: a(:)) &
+!$omp& map(from: b(:))
+```
+
+Highlights:
+
+- Trailing `&` characters, even when separated by spaces from the sentinel, mark a continuation.
+- A leading `&` on the next line is optional; if present it is discarded automatically.
+- Sentinel repetition (`!$omp`, `!$OMP`, etc.) on continuation lines is supported but not required.
+- Indentation and blank lines between continued sections are tolerated.
+
+## Fortran Fixed-Form Example
+
+```fortran
+      C$OMP PARALLEL DO&
+      C$OMP& PRIVATE(I) &
+      C$OMP  SCHEDULE(STATIC)
+```
+
+Rules of thumb:
+
+- Continuation lines may use any of the standard sentinels (`C$OMP`, `!$OMP`, or `*$OMP`).
+- Column 6 `&` markers are optional; when present they are removed by the lexer.
+- Mixed-case sentinels are accepted, matching the behaviour of common Fortran compilers.
+
+## Diagnostics and Edge Cases
+
+- Continuations must follow standard OpenMP syntax. Non-standard tokens (e.g., a trailing comma without `&`) will surface as parse errors.
+- Clauses that contain literal `&` characters (for example, bitwise expressions in C) continue to parse correctly because the lexer only treats an ampersand as a continuation when it appears at a line boundary.
+- Unterminated continuations (a trailing backslash with no subsequent line, or a Fortran line ending with `&` at end-of-file) are reported as parser errors.
+
+## Interoperability
+
+- The ompparser compatibility layer uses the same normalisation pipeline. Tests in `compat/ompparser/tests/comprehensive_test.cpp` cover multi-line directives to guard against regressions.
+- The C API (`roup_parse`) automatically enables continuation handling; callers do not need extra flags.
+
+## Further Reading
+
+- [Fortran Tutorial](./fortran-tutorial.md) – background on language modes and sentinel selection.
+- [C Tutorial](./c-tutorial.md) – directive structure and clause registry overview.

--- a/tests/openmp_line_continuations.rs
+++ b/tests/openmp_line_continuations.rs
@@ -1,0 +1,70 @@
+//! Integration tests for OpenMP line continuation handling across languages.
+//!
+//! These tests exercise the lexer normalization that stitches multi-line
+//! directives into the logical single-line representation consumed by the
+//! parser. Both unit-level coverage (lexer tests) and end-to-end parser
+//! coverage are provided to ensure the continuation rules stay in sync.
+
+use roup::lexer::Language;
+use roup::parser::openmp;
+
+#[test]
+fn parses_c_pragma_with_backslash_continuation() {
+    let parser = openmp::parser().with_language(Language::C);
+    let input = [
+        "#pragma omp parallel \\",
+        "// preserve structure just like in source files",
+        "    default(shared) \\",
+        "    private(i, j)",
+    ]
+    .join("\n");
+
+    let (rest, directive) = parser.parse(&input).expect("parsing should succeed");
+
+    assert_eq!(rest.trim(), "");
+    assert_eq!(directive.name, "parallel");
+    assert_eq!(directive.clauses.len(), 2);
+    assert_eq!(directive.clauses[0].name, "default");
+    assert_eq!(directive.clauses[1].name, "private");
+}
+
+#[test]
+fn parses_fortran_free_with_repeated_sentinel() {
+    let parser = openmp::parser().with_language(Language::FortranFree);
+    let input = "!$OMP PARALLEL DO &\n!$OMP& PRIVATE(I, J) &\n!$OMP  SCHEDULE(STATIC)";
+
+    let (rest, directive) = parser.parse(input).expect("parsing should succeed");
+
+    assert_eq!(rest.trim(), "");
+    assert_eq!(directive.name.to_lowercase(), "parallel do");
+    assert_eq!(directive.clauses.len(), 2);
+    assert_eq!(directive.clauses[0].name.to_lowercase(), "private");
+    assert_eq!(directive.clauses[1].name.to_lowercase(), "schedule");
+}
+
+#[test]
+fn parses_fortran_free_with_leading_ampersand() {
+    let parser = openmp::parser().with_language(Language::FortranFree);
+    let input = "!$omp parallel &\n  private(i) &\n& num_threads(4)";
+
+    let (rest, directive) = parser.parse(input).expect("parsing should succeed");
+
+    assert_eq!(rest.trim(), "");
+    assert_eq!(directive.name.to_lowercase(), "parallel");
+    assert_eq!(directive.clauses.len(), 2);
+    assert_eq!(directive.clauses[0].name.to_lowercase(), "private");
+    assert_eq!(directive.clauses[1].name.to_lowercase(), "num_threads");
+}
+
+#[test]
+fn parses_fortran_fixed_with_column_six_ampersand() {
+    let parser = openmp::parser().with_language(Language::FortranFixed);
+    let input = "C$OMP PARALLEL DO&\nC$OMP& PRIVATE(I)";
+
+    let (rest, directive) = parser.parse(input).expect("parsing should succeed");
+
+    assert_eq!(rest.trim(), "");
+    assert_eq!(directive.name.to_lowercase(), "parallel do");
+    assert_eq!(directive.clauses.len(), 1);
+    assert_eq!(directive.clauses[0].name.to_lowercase(), "private");
+}


### PR DESCRIPTION
## Summary
- normalize C/C++ backslash continuations and Fortran ampersand/sentinel patterns in the lexer with new regression coverage
- extend the ompparser compatibility layer to pass explicit language hints and add continuation-focused end-to-end tests
- document multi-line directive handling, add a dedicated guide, and wire in targeted parser integration tests

## Testing
- `cargo test`
- `cd compat/ompparser && ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ed19d35480832fba9c18b091cc114b