### PR TITLE
feat: support multi-line OpenMP directives

### DIFF
--- a/docs/CONSTANTS_ARCHITECTURE.md
+++ b/docs/CONSTANTS_ARCHITECTURE.md
@@ -23,7 +23,7 @@ fn directive_name_to_kind(name: *const c_char) -> i32 {
 }
 
 fn convert_clause(clause: &Clause) -> OmpClause {
-    let (kind, data) = match clause.name {
+    let (kind, data) = match clause.name.as_ref() {
         "num_threads" => (0, ...),
         "if" => (1, ...),
         // ... etc

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -19,6 +19,7 @@
 
 - [API Reference](./api-reference.md)
 - [OpenMP Support Matrix](./openmp-support.md)
+- [Line Continuations](./line-continuations.md)
 
 # Developer Guide
 

--- a/docs/book/src/fortran-tutorial.md
+++ b/docs/book/src/fortran-tutorial.md
@@ -305,17 +305,10 @@ my_program: my_program.f90
 
 ⚠️ **Current limitations in experimental Fortran support:**
 
-1. **Single-Line Input Only**: ROUP requires complete directives on a single line
-   - **Not supported**: Multi-line directives with `&` continuation
-     ```fortran
-     !$OMP PARALLEL DO &
-     !$OMP   PRIVATE(I,J)
-     ```
-   - **Workaround**: Provide complete directive on one line:
-     ```fortran
-     !$OMP PARALLEL DO PRIVATE(I,J)
-     ```
-   - **Rationale**: This is an architectural design constraint that applies to both C and Fortran. Users must preprocess multi-line directives into single lines before passing to ROUP.
+1. **Continuation Syntax Requirements**: Multi-line directives must use standard continuation markers
+   - **Fortran**: Terminate continued lines with `&` and optionally repeat the sentinel on the next line
+   - **C/C++**: Place a trailing `\` at the end of each continued line
+   - See [Line Continuations](./line-continuations.md) for canonical examples across languages
 
 2. **End Directives**: `!$OMP END PARALLEL` and similar end directives may not parse correctly
 

--- a/docs/book/src/line-continuations.md
+++ b/docs/book/src/line-continuations.md
@@ -1,0 +1,75 @@
+# Line Continuations
+
+⚠️ Experimental: ROUP now understands multi-line OpenMP directives across C, C++, and Fortran. This guide shows how to format
+continuations so the parser and ompparser compatibility layer recognize them reliably.
+
+## When to use continuations
+
+OpenMP pragmas often grow long once multiple clauses are attached. Rather than forcing everything onto a single line, you can
+split directives while keeping source files readable. ROUP stitches the continued lines together during lexing, so downstream
+APIs still observe canonical single-line directive strings.
+
+Continuations are supported in two situations:
+
+- **C / C++ pragmas** that end a line with a trailing backslash (`\`).
+- **Fortran sentinels** (`!$OMP`, `C$OMP`, `*$OMP`) that use the standard ampersand (`&`) continuation syntax.
+
+ROUP preserves clause order and trims whitespace that was introduced only to align indentation.
+
+## C / C++ example
+
+```c
+#pragma omp parallel for \
+    schedule(dynamic, 4) \
+    private(i, \
+            j)
+```
+
+ROUP merges this directive into `#pragma omp parallel for schedule(dynamic, 4) private(i, j)`. Clause arguments keep their
+original spacing. Comments (`/* */` or `//`) may appear between continued lines and are ignored during merging.
+
+### Tips for C / C++
+
+- The backslash must be the final character on the line (aside from trailing spaces or tabs).
+- Windows line endings (`\r\n`) are handled automatically.
+- Keep at least one space between the directive name and the first clause on subsequent lines.
+
+## Fortran free-form example
+
+```fortran
+!$omp target teams distribute &
+!$omp parallel do &
+!$omp& private(i, j)
+```
+
+The parser removes the continuation markers and produces `!$omp target teams distribute parallel do private(i, j)`.
+
+### Fortran fixed-form example
+
+```fortran
+      C$OMP   DO &
+      !$OMP& SCHEDULE(DYNAMIC) &
+      !$OMP PRIVATE(I) SHARED(A)
+```
+
+Column prefixes (`!`, `C`, or `*`) are respected. ROUP normalizes the directive to `do schedule(DYNAMIC) private(I) shared(A)`.
+
+### Tips for Fortran continuations
+
+- Terminate every continued line with `&`. ROUP tolerates trailing comments (e.g., `& ! explanation`) and skips them automatically.
+- You may repeat the sentinel on continuation lines (`!$OMP&`), or start the next line with only `&`. Both forms are accepted.
+- Blank continuation lines are ignored as long as they contain only whitespace.
+- Clause bodies can span multiple lines; nested continuations inside parentheses are collapsed to a single line in the parsed
+  clause value.
+
+## Troubleshooting
+
+- **Missing continuation marker**: If a line break appears without `&` (Fortran) or `\` (C/C++), the parser treats the next line
+  as a separate statement and reports an error or unexpected directive name.
+- **Custom formatting macros**: Preprocessors that insert trailing spaces after `\` may break continuations. Ensure the backslash
+  is the final printable character.
+- **Compatibility layer**: The ompparser shim mirrors the same behavior. The comprehensive tests in
+  `compat/ompparser/tests/comprehensive_test.cpp` include multi-line inputs for both languages.
+
+For more examples, refer to the automated tests in `tests/openmp_line_continuations.rs` and the parser unit tests in
+`src/parser/mod.rs`.

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -227,7 +227,7 @@ pub extern "C" fn roup_parse(input: *const c_char) -> *mut OmpDirective {
 
     // Convert to C-compatible format
     let c_directive = OmpDirective {
-        name: allocate_c_string(directive.name),
+        name: allocate_c_string(directive.name.as_ref()),
         clauses: directive
             .clauses
             .into_iter()
@@ -347,7 +347,7 @@ pub extern "C" fn roup_parse_with_language(
 
     // Convert to C-compatible format
     let c_directive = OmpDirective {
-        name: allocate_c_string(directive.name),
+        name: allocate_c_string(directive.name.as_ref()),
         clauses: directive
             .clauses
             .into_iter()
@@ -774,7 +774,8 @@ fn convert_clause(clause: &Clause) -> OmpClause {
 /// - 4 = |  (bitwise OR)    - 9 = max
 fn parse_reduction_operator(clause: &Clause) -> i32 {
     // Look for operator in clause kind
-    if let ClauseKind::Parenthesized(args) = clause.kind {
+    if let ClauseKind::Parenthesized(ref args) = clause.kind {
+        let args = args.as_ref();
         // Operators (+, -, *, etc.) are ASCII symbols - no case conversion needed
         if args.contains('+') && !args.contains("++") {
             return 0; // Plus
@@ -817,7 +818,8 @@ fn parse_reduction_operator(clause: &Clause) -> i32 {
 /// - 3 = auto     (compiler decides)
 /// - 4 = runtime  (OMP_SCHEDULE environment variable)
 fn parse_schedule_kind(clause: &Clause) -> i32 {
-    if let ClauseKind::Parenthesized(args) = clause.kind {
+    if let ClauseKind::Parenthesized(ref args) = clause.kind {
+        let args = args.as_ref();
         // Case-insensitive keyword matching without String allocation
         // Check common case variants (lowercase, uppercase, title case)
         if args.contains("static") || args.contains("STATIC") || args.contains("Static") {
@@ -844,7 +846,8 @@ fn parse_schedule_kind(clause: &Clause) -> i32 {
 /// - 0 = shared (all variables shared by default)
 /// - 1 = none   (must explicitly declare all variables)
 fn parse_default_kind(clause: &Clause) -> i32 {
-    if let ClauseKind::Parenthesized(args) = clause.kind {
+    if let ClauseKind::Parenthesized(ref args) = clause.kind {
+        let args = args.as_ref();
         // Case-insensitive keyword matching without String allocation
         // Check common case variants (lowercase, uppercase, title case)
         if args.contains("shared") || args.contains("SHARED") || args.contains("Shared") {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -14,6 +14,8 @@
 /// - Input: &str (string slice to parse)
 /// - Output: &str (parsed token)
 /// - Returns: Ok((remaining_input, parsed_output)) or Err
+use std::borrow::Cow;
+
 use nom::IResult;
 
 /// Learning Rust: Importing from External Crates
@@ -124,28 +126,6 @@ pub fn lex_fortran_fixed_sentinel(input: &str) -> IResult<&str, &str> {
     }
 }
 
-// ============================================================================
-// Fortran Continuation Lines - NOT SUPPORTED BY DESIGN
-// ============================================================================
-//
-// ROUP does NOT support multi-line Fortran directives with continuation (&).
-//
-// Example of UNSUPPORTED input:
-//     !$OMP PARALLEL DO &
-//     !$OMP   PRIVATE(I,J)
-//
-// Design Decision:
-// - Continuation handling requires stateful multi-line parsing
-// - Users must provide complete single-line directives
-// - Applies to BOTH C and Fortran (no multi-line #pragma either)
-//
-// Workaround:
-// - Preprocess multi-line directives into single lines before calling parse()
-// - Example: "!$OMP PARALLEL DO PRIVATE(I,J)" (all on one line)
-//
-// See: src/parser/mod.rs Parser::parse() for rationale
-// ============================================================================
-
 /// Parse an identifier (directive or clause name)
 ///
 /// Learning Rust: Higher-Order Functions
@@ -179,6 +159,18 @@ pub fn skip_space_and_comments(input: &str) -> IResult<&str, &str> {
     let len = bytes.len();
 
     while i < len {
+        // Handle C/C++ line continuations using backslash-newline
+        if let Some(next_idx) = skip_c_line_continuation(input, i) {
+            i = next_idx;
+            continue;
+        }
+
+        // Handle Fortran continuation markers using trailing ampersand
+        if let Some(next_idx) = skip_fortran_continuation(input, i) {
+            i = next_idx;
+            continue;
+        }
+
         // Learning Rust: Working with Bytes
         // ==================================
         // .as_bytes() converts &str to &[u8] (byte slice)
@@ -242,6 +234,173 @@ pub fn skip_space1_and_comments(input: &str) -> IResult<&str, &str> {
 /// Parse an identifier token (exposed publicly)
 pub fn lex_identifier_token(input: &str) -> IResult<&str, &str> {
     lex_identifier(input)
+}
+
+pub(crate) fn collapse_line_continuations<'a>(input: &'a str) -> Cow<'a, str> {
+    if !input.contains('\\') && !input.contains('&') {
+        return Cow::Borrowed(input);
+    }
+
+    let mut output = String::with_capacity(input.len());
+    let mut idx = 0;
+    let bytes = input.as_bytes();
+    let len = bytes.len();
+    let mut changed = false;
+
+    while idx < len {
+        if bytes[idx] == b'\\' {
+            let mut next = idx + 1;
+            while next < len && matches!(bytes[next], b' ' | b'\t') {
+                next += 1;
+            }
+            if next < len && (bytes[next] == b'\n' || bytes[next] == b'\r') {
+                changed = true;
+                if bytes[next] == b'\r' {
+                    next += 1;
+                    if next < len && bytes[next] == b'\n' {
+                        next += 1;
+                    }
+                } else {
+                    next += 1;
+                }
+                while next < len && matches!(bytes[next], b' ' | b'\t') {
+                    next += 1;
+                }
+                idx = next;
+                continue;
+            }
+        } else if bytes[idx] == b'&' {
+            if let Some(next) = skip_fortran_continuation(input, idx) {
+                changed = true;
+                idx = next;
+                continue;
+            }
+        }
+
+        let ch = input[idx..].chars().next().unwrap();
+        output.push(ch);
+        idx += ch.len_utf8();
+    }
+
+    if changed {
+        Cow::Owned(output)
+    } else {
+        Cow::Borrowed(input)
+    }
+}
+
+fn skip_c_line_continuation(input: &str, idx: usize) -> Option<usize> {
+    let bytes = input.as_bytes();
+    let len = bytes.len();
+    if idx >= len || bytes[idx] != b'\\' {
+        return None;
+    }
+
+    let mut next = idx + 1;
+    while next < len && matches!(bytes[next], b' ' | b'\t') {
+        next += 1;
+    }
+
+    if next >= len {
+        return Some(len);
+    }
+
+    match bytes[next] {
+        b'\n' => {
+            next += 1;
+        }
+        b'\r' => {
+            next += 1;
+            if next < len && bytes[next] == b'\n' {
+                next += 1;
+            }
+        }
+        _ => return None,
+    }
+
+    while next < len && matches!(bytes[next], b' ' | b'\t') {
+        next += 1;
+    }
+
+    Some(next)
+}
+
+fn skip_fortran_continuation(input: &str, idx: usize) -> Option<usize> {
+    let bytes = input.as_bytes();
+    let len = bytes.len();
+    if idx >= len || bytes[idx] != b'&' {
+        return None;
+    }
+
+    let mut next = idx + 1;
+
+    while next < len {
+        match bytes[next] {
+            b' ' | b'\t' => next += 1,
+            b'!' => {
+                next += 1;
+                while next < len && bytes[next] != b'\n' && bytes[next] != b'\r' {
+                    next += 1;
+                }
+                break;
+            }
+            b'\n' | b'\r' => break,
+            _ => return None,
+        }
+    }
+
+    if next >= len {
+        return Some(len);
+    }
+
+    if bytes[next] == b'\r' {
+        next += 1;
+        if next < len && bytes[next] == b'\n' {
+            next += 1;
+        }
+    } else if bytes[next] == b'\n' {
+        next += 1;
+    } else {
+        return None;
+    }
+
+    while next < len {
+        match bytes[next] {
+            b' ' | b'\t' => next += 1,
+            b'\r' | b'\n' => {
+                next += 1;
+            }
+            _ => break,
+        }
+    }
+
+    if let Some(len_sent) = match_fortran_sentinel(&input[next..]) {
+        next += len_sent;
+        while next < len && matches!(bytes[next], b' ' | b'\t') {
+            next += 1;
+        }
+    }
+
+    if next < len && bytes[next] == b'&' {
+        next += 1;
+        while next < len && matches!(bytes[next], b' ' | b'\t') {
+            next += 1;
+        }
+    }
+
+    Some(next)
+}
+
+fn match_fortran_sentinel(input: &str) -> Option<usize> {
+    let candidates = ["!$omp", "c$omp", "*$omp"];
+    for candidate in candidates {
+        if input.len() >= candidate.len()
+            && input[..candidate.len()].eq_ignore_ascii_case(candidate)
+        {
+            return Some(candidate.len());
+        }
+    }
+    None
 }
 
 #[cfg(test)]
@@ -324,6 +483,32 @@ mod tests {
 
         let result = skip_space1_and_comments(" has_space");
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn skip_space_handles_c_line_continuations() {
+        let (rest, _) = skip_space_and_comments("\\\n    default(none)").unwrap();
+        assert_eq!(rest, "default(none)");
+    }
+
+    #[test]
+    fn skip_space_handles_fortran_continuations() {
+        let input = "&\n!$omp private(i, j)";
+        let (rest, _) = skip_space_and_comments(input).unwrap();
+        assert_eq!(rest, "private(i, j)");
+    }
+
+    #[test]
+    fn collapse_line_continuations_removes_c_backslash() {
+        let collapsed = collapse_line_continuations(concat!("a, \\\n", "    b"));
+        assert_eq!(collapsed.as_ref(), "a, b");
+    }
+
+    #[test]
+    fn collapse_line_continuations_removes_fortran_ampersand() {
+        let input = "items( i, &\n!$omp& j )";
+        let collapsed = collapse_line_continuations(input);
+        assert_eq!(collapsed.as_ref(), "items( i, j )");
     }
 
     #[test]

--- a/tests/openmp_comments_and_nested.rs
+++ b/tests/openmp_comments_and_nested.rs
@@ -16,10 +16,13 @@ fn parses_clause_with_nested_parentheses() {
     assert_eq!(directive.clauses[0].name, "reduction");
     assert_eq!(
         directive.clauses[0].kind,
-        ClauseKind::Parenthesized("max:(f(a), g(b))")
+        ClauseKind::Parenthesized("max:(f(a), g(b))".into())
     );
     assert_eq!(directive.clauses[1].name, "private");
-    assert_eq!(directive.clauses[1].kind, ClauseKind::Parenthesized("i"));
+    assert_eq!(
+        directive.clauses[1].kind,
+        ClauseKind::Parenthesized("i".into())
+    );
 }
 
 #[test]
@@ -30,5 +33,8 @@ fn parses_pragma_with_comments_inside() {
     assert_eq!(directive.name, "parallel");
     assert_eq!(directive.clauses.len(), 1);
     assert_eq!(directive.clauses[0].name, "private");
-    assert_eq!(directive.clauses[0].kind, ClauseKind::Parenthesized("a"));
+    assert_eq!(
+        directive.clauses[0].kind,
+        ClauseKind::Parenthesized("a".into())
+    );
 }

--- a/tests/openmp_for.rs
+++ b/tests/openmp_for.rs
@@ -15,12 +15,18 @@ fn parses_for_with_iteration_clauses() {
     assert_eq!(directive.clauses[0].name, "schedule");
     assert_eq!(
         directive.clauses[0].kind,
-        ClauseKind::Parenthesized("guided,16")
+        ClauseKind::Parenthesized("guided,16".into())
     );
     assert_eq!(directive.clauses[1].name, "ordered");
-    assert_eq!(directive.clauses[1].kind, ClauseKind::Parenthesized("2"));
+    assert_eq!(
+        directive.clauses[1].kind,
+        ClauseKind::Parenthesized("2".into())
+    );
     assert_eq!(directive.clauses[2].name, "private");
-    assert_eq!(directive.clauses[2].kind, ClauseKind::Parenthesized("i, j"));
+    assert_eq!(
+        directive.clauses[2].kind,
+        ClauseKind::Parenthesized("i, j".into())
+    );
 }
 
 #[test]
@@ -31,15 +37,24 @@ fn parses_for_simd_with_linear_clause() {
     assert_eq!(directive.name, "for simd");
     assert_eq!(directive.clauses.len(), 4);
     assert_eq!(directive.clauses[0].name, "linear");
-    assert_eq!(directive.clauses[0].kind, ClauseKind::Parenthesized("x:2"));
+    assert_eq!(
+        directive.clauses[0].kind,
+        ClauseKind::Parenthesized("x:2".into())
+    );
     assert_eq!(directive.clauses[1].name, "safelen");
-    assert_eq!(directive.clauses[1].kind, ClauseKind::Parenthesized("8"));
+    assert_eq!(
+        directive.clauses[1].kind,
+        ClauseKind::Parenthesized("8".into())
+    );
     assert_eq!(directive.clauses[2].name, "simdlen");
-    assert_eq!(directive.clauses[2].kind, ClauseKind::Parenthesized("4"));
+    assert_eq!(
+        directive.clauses[2].kind,
+        ClauseKind::Parenthesized("4".into())
+    );
     assert_eq!(directive.clauses[3].name, "reduction");
     assert_eq!(
         directive.clauses[3].kind,
-        ClauseKind::Parenthesized("-:diff")
+        ClauseKind::Parenthesized("-:diff".into())
     );
 }
 

--- a/tests/openmp_line_continuations.rs
+++ b/tests/openmp_line_continuations.rs
@@ -1,0 +1,120 @@
+use roup::lexer::Language;
+use roup::parser::{ClauseKind, Directive, Parser};
+
+fn parse_with_language(input: &str, language: Language) -> Directive<'_> {
+    let parser = Parser::default().with_language(language);
+    let (_, directive) = parser.parse(input).expect("directive should parse");
+    directive
+}
+
+#[test]
+fn parses_c_multiline_with_backslash() {
+    let directive = parse_with_language(
+        concat!(
+            "#pragma omp parallel for \\\n",
+            "    schedule(dynamic, 4) \\\n",
+            "    private(i, \\\n",
+            "            j)"
+        ),
+        Language::C,
+    );
+
+    assert_eq!(directive.name, "parallel for");
+    assert_eq!(directive.clauses.len(), 2);
+    assert_eq!(directive.clauses[0].name, "schedule");
+    assert_eq!(
+        directive.clauses[0].kind,
+        ClauseKind::Parenthesized("dynamic, 4".into())
+    );
+    assert_eq!(directive.clauses[1].name, "private");
+    assert_eq!(
+        directive.clauses[1].kind,
+        ClauseKind::Parenthesized("i, j".into())
+    );
+}
+
+#[test]
+fn parses_c_multiline_with_comments() {
+    let directive = parse_with_language(
+        concat!(
+            "#pragma omp parallel for \\\n",
+            "    /* align workers */ schedule(static, 2) \\\n",
+            "    // items below\n",
+            "    private(a)"
+        ),
+        Language::C,
+    );
+
+    assert_eq!(directive.name, "parallel for");
+    assert_eq!(directive.clauses.len(), 2);
+    assert_eq!(directive.clauses[0].name, "schedule");
+    assert_eq!(
+        directive.clauses[0].kind,
+        ClauseKind::Parenthesized("static, 2".into())
+    );
+    assert_eq!(directive.clauses[1].name, "private");
+    assert_eq!(
+        directive.clauses[1].kind,
+        ClauseKind::Parenthesized("a".into())
+    );
+}
+
+#[test]
+fn parses_fortran_free_with_ampersand() {
+    let directive = parse_with_language(
+        concat!("!$omp parallel do &\n", "!$omp private(i, &\n", "!$omp& j)"),
+        Language::FortranFree,
+    );
+
+    assert_eq!(directive.name, "parallel do");
+    assert_eq!(directive.clauses.len(), 1);
+    assert_eq!(directive.clauses[0].name, "private");
+    assert_eq!(
+        directive.clauses[0].kind,
+        ClauseKind::Parenthesized("i, j".into())
+    );
+}
+
+#[test]
+fn parses_fortran_free_with_comment_continuation() {
+    let directive = parse_with_language(
+        concat!(
+            "!$omp parallel do private(i, & ! trailing comment\n",
+            "!$omp& j, k)"
+        ),
+        Language::FortranFree,
+    );
+
+    assert_eq!(directive.name, "parallel do");
+    assert_eq!(directive.clauses.len(), 1);
+    assert_eq!(directive.clauses[0].name, "private");
+    assert_eq!(
+        directive.clauses[0].kind,
+        ClauseKind::Parenthesized("i, j, k".into())
+    );
+}
+
+#[test]
+fn parses_fortran_fixed_with_mixed_sentinels() {
+    let directive = parse_with_language(
+        concat!(
+            "      !$OMP TEAMS DISTRIBUTE &\n",
+            "      C$OMP& PARALLEL DO &\n",
+            "      !$OMP PRIVATE(I) SHARED(A)"
+        ),
+        Language::FortranFixed,
+    );
+
+    assert_eq!(directive.name, "teams distribute parallel do");
+    assert_eq!(directive.clauses.len(), 2);
+    assert_eq!(directive.clauses[0].name, "private");
+    assert_eq!(
+        directive.clauses[0].kind,
+        ClauseKind::Parenthesized("I".into())
+    );
+    assert_eq!(directive.clauses[1].name, "shared");
+    assert_eq!(
+        directive.clauses[1].kind,
+        ClauseKind::Parenthesized("A".into())
+    );
+}

--- a/tests/openmp_metadirective.rs
+++ b/tests/openmp_metadirective.rs
@@ -25,7 +25,7 @@ fn parses_metadirective_with_all_context_selectors() {
     assert!(matches!(first_when.kind, ClauseKind::Parenthesized(_)));
     if let ClauseKind::Parenthesized(body) = &first_when.kind {
         assert_eq!(
-            *body,
+            body.as_ref(),
             "device={kind(cpu), isa(avx512f), arch(gen)}, implementation={vendor(llvm), extension(match_extension), atomic_default_mem_order(seq_cst)}, user={condition(iterations>0)}, construct={parallel, for, simd}: parallel for schedule(static,1)"
         );
     }
@@ -34,7 +34,7 @@ fn parses_metadirective_with_all_context_selectors() {
     assert_eq!(second_when.name, "when");
     if let ClauseKind::Parenthesized(body) = &second_when.kind {
         assert_eq!(
-            *body,
+            body.as_ref(),
             "device={kind(gpu)}, construct={teams, distribute}, implementation={extension(distributed)}, user={condition(flag != 0)}: teams distribute parallel for"
         );
     } else {
@@ -44,7 +44,7 @@ fn parses_metadirective_with_all_context_selectors() {
     let default_clause = &directive.clauses[2];
     assert_eq!(default_clause.name, "default");
     if let ClauseKind::Parenthesized(body) = &default_clause.kind {
-        assert_eq!(*body, "parallel for reduction(task,inscan,+:sum)");
+        assert_eq!(body.as_ref(), "parallel for reduction(task,inscan,+:sum)");
     } else {
         panic!("expected parenthesized clause for default");
     }
@@ -77,7 +77,7 @@ fn parses_metadirective_with_nested_directives_and_qualifiers() {
         .clauses
         .iter()
         .map(|clause| match &clause.kind {
-            ClauseKind::Parenthesized(body) => *body,
+            ClauseKind::Parenthesized(body) => body.as_ref(),
             ClauseKind::Bare => panic!("expected parenthesized clause"),
         })
         .collect();

--- a/tests/openmp_parallel.rs
+++ b/tests/openmp_parallel.rs
@@ -13,9 +13,15 @@ fn parses_parallel_with_core_clauses() {
     assert_eq!(directive.name, "parallel");
     assert_eq!(directive.clauses.len(), 3);
     assert_eq!(directive.clauses[0].name, "private");
-    assert_eq!(directive.clauses[0].kind, ClauseKind::Parenthesized("a, b"));
+    assert_eq!(
+        directive.clauses[0].kind,
+        ClauseKind::Parenthesized("a, b".into())
+    );
     assert_eq!(directive.clauses[1].name, "firstprivate");
-    assert_eq!(directive.clauses[1].kind, ClauseKind::Parenthesized("c"));
+    assert_eq!(
+        directive.clauses[1].kind,
+        ClauseKind::Parenthesized("c".into())
+    );
     assert_eq!(directive.clauses[2].name, "nowait");
     assert_eq!(directive.clauses[2].kind, ClauseKind::Bare);
 }
@@ -31,19 +37,22 @@ fn parses_parallel_for_simd_combination() {
     assert_eq!(directive.clauses[0].name, "aligned");
     assert_eq!(
         directive.clauses[0].kind,
-        ClauseKind::Parenthesized("buf:64"),
+        ClauseKind::Parenthesized("buf:64".into()),
     );
     assert_eq!(directive.clauses[1].name, "schedule");
     assert_eq!(
         directive.clauses[1].kind,
-        ClauseKind::Parenthesized("static,4")
+        ClauseKind::Parenthesized("static,4".into())
     );
     assert_eq!(directive.clauses[2].name, "collapse");
-    assert_eq!(directive.clauses[2].kind, ClauseKind::Parenthesized("2"));
+    assert_eq!(
+        directive.clauses[2].kind,
+        ClauseKind::Parenthesized("2".into())
+    );
     assert_eq!(directive.clauses[3].name, "reduction");
     assert_eq!(
         directive.clauses[3].kind,
-        ClauseKind::Parenthesized("+:sum"),
+        ClauseKind::Parenthesized("+:sum".into()),
     );
 }
 

--- a/tests/openmp_reduction.rs
+++ b/tests/openmp_reduction.rs
@@ -22,7 +22,7 @@ fn parses_reduction_clause_with_modifiers_and_operators() {
     for (clause, expected_body) in directive.clauses.iter().zip(expected.into_iter()) {
         assert_eq!(clause.name, "reduction");
         match &clause.kind {
-            ClauseKind::Parenthesized(body) => assert_eq!(*body, expected_body),
+            ClauseKind::Parenthesized(body) => assert_eq!(body.as_ref(), expected_body),
             ClauseKind::Bare => panic!("reduction clauses should be parenthesized"),
         }
     }
@@ -43,7 +43,7 @@ fn parses_reduction_clause_with_user_defined_identifier() {
     assert_eq!(directive.clauses[0].name, "reduction");
     match &directive.clauses[0].kind {
         ClauseKind::Parenthesized(body) => {
-            assert_eq!(*body, "user_addition:accumulator");
+            assert_eq!(body.as_ref(), "user_addition:accumulator");
         }
         ClauseKind::Bare => panic!("reduction clause should be parenthesized"),
     }
@@ -51,7 +51,7 @@ fn parses_reduction_clause_with_user_defined_identifier() {
     assert_eq!(directive.clauses[1].name, "reduction");
     match &directive.clauses[1].kind {
         ClauseKind::Parenthesized(body) => {
-            assert_eq!(*body, "task, custom_reducer:list");
+            assert_eq!(body.as_ref(), "task, custom_reducer:list");
         }
         ClauseKind::Bare => panic!("reduction clause should be parenthesized"),
     }

--- a/tests/openmp_target.rs
+++ b/tests/openmp_target.rs
@@ -15,14 +15,17 @@ fn parses_target_with_mapping_clauses() {
     assert_eq!(directive.clauses[0].name, "if");
     assert_eq!(
         directive.clauses[0].kind,
-        ClauseKind::Parenthesized("device")
+        ClauseKind::Parenthesized("device".into())
     );
     assert_eq!(directive.clauses[1].name, "device");
-    assert_eq!(directive.clauses[1].kind, ClauseKind::Parenthesized("0"));
+    assert_eq!(
+        directive.clauses[1].kind,
+        ClauseKind::Parenthesized("0".into())
+    );
     assert_eq!(directive.clauses[2].name, "map");
     assert_eq!(
         directive.clauses[2].kind,
-        ClauseKind::Parenthesized("tofrom:array[0:N]"),
+        ClauseKind::Parenthesized("tofrom:array[0:N]".into()),
     );
     assert_eq!(directive.clauses[3].name, "nowait");
     assert_eq!(directive.clauses[3].kind, ClauseKind::Bare);
@@ -38,22 +41,28 @@ fn parses_target_teams_distribute_parallel_for_simd() {
     assert_eq!(directive.name, "target teams distribute parallel for simd");
     assert_eq!(directive.clauses.len(), 5);
     assert_eq!(directive.clauses[0].name, "num_teams");
-    assert_eq!(directive.clauses[0].kind, ClauseKind::Parenthesized("4"));
+    assert_eq!(
+        directive.clauses[0].kind,
+        ClauseKind::Parenthesized("4".into())
+    );
     assert_eq!(directive.clauses[1].name, "thread_limit");
-    assert_eq!(directive.clauses[1].kind, ClauseKind::Parenthesized("128"));
+    assert_eq!(
+        directive.clauses[1].kind,
+        ClauseKind::Parenthesized("128".into())
+    );
     assert_eq!(directive.clauses[2].name, "schedule");
     assert_eq!(
         directive.clauses[2].kind,
-        ClauseKind::Parenthesized("dynamic,8")
+        ClauseKind::Parenthesized("dynamic,8".into())
     );
     assert_eq!(directive.clauses[3].name, "reduction");
     assert_eq!(
         directive.clauses[3].kind,
-        ClauseKind::Parenthesized("*:prod")
+        ClauseKind::Parenthesized("*:prod".into())
     );
     assert_eq!(directive.clauses[4].name, "uses_allocators");
     assert_eq!(
         directive.clauses[4].kind,
-        ClauseKind::Parenthesized("omp_default_mem_alloc"),
+        ClauseKind::Parenthesized("omp_default_mem_alloc".into()),
     );
 }

--- a/tests/openmp_task.rs
+++ b/tests/openmp_task.rs
@@ -17,19 +17,28 @@ fn parses_task_with_dependencies() {
     assert_eq!(directive.clauses[0].name, "if");
     assert_eq!(
         directive.clauses[0].kind,
-        ClauseKind::Parenthesized("inbranch")
+        ClauseKind::Parenthesized("inbranch".into())
     );
     assert_eq!(directive.clauses[1].name, "final");
-    assert_eq!(directive.clauses[1].kind, ClauseKind::Parenthesized("true"));
+    assert_eq!(
+        directive.clauses[1].kind,
+        ClauseKind::Parenthesized("true".into())
+    );
     assert_eq!(directive.clauses[2].name, "priority");
-    assert_eq!(directive.clauses[2].kind, ClauseKind::Parenthesized("3"));
+    assert_eq!(
+        directive.clauses[2].kind,
+        ClauseKind::Parenthesized("3".into())
+    );
     assert_eq!(directive.clauses[3].name, "depend");
     assert_eq!(
         directive.clauses[3].kind,
-        ClauseKind::Parenthesized("inout:buf")
+        ClauseKind::Parenthesized("inout:buf".into())
     );
     assert_eq!(directive.clauses[4].name, "detach");
-    assert_eq!(directive.clauses[4].kind, ClauseKind::Parenthesized("evt"));
+    assert_eq!(
+        directive.clauses[4].kind,
+        ClauseKind::Parenthesized("evt".into())
+    );
 }
 
 #[test]
@@ -41,14 +50,23 @@ fn parses_taskloop_simd_with_grainsize() {
     assert_eq!(directive.name, "taskloop simd");
     assert_eq!(directive.clauses.len(), 4);
     assert_eq!(directive.clauses[0].name, "grainsize");
-    assert_eq!(directive.clauses[0].kind, ClauseKind::Parenthesized("4"));
+    assert_eq!(
+        directive.clauses[0].kind,
+        ClauseKind::Parenthesized("4".into())
+    );
     assert_eq!(directive.clauses[1].name, "num_tasks");
-    assert_eq!(directive.clauses[1].kind, ClauseKind::Parenthesized("16"));
+    assert_eq!(
+        directive.clauses[1].kind,
+        ClauseKind::Parenthesized("16".into())
+    );
     assert_eq!(directive.clauses[2].name, "reduction");
     assert_eq!(
         directive.clauses[2].kind,
-        ClauseKind::Parenthesized("max:max_val")
+        ClauseKind::Parenthesized("max:max_val".into())
     );
     assert_eq!(directive.clauses[3].name, "shared");
-    assert_eq!(directive.clauses[3].kind, ClauseKind::Parenthesized("out"));
+    assert_eq!(
+        directive.clauses[3].kind,
+        ClauseKind::Parenthesized("out".into())
+    );
 }

--- a/tests/openmp_teams.rs
+++ b/tests/openmp_teams.rs
@@ -13,13 +13,19 @@ fn parses_teams_with_reductions() {
     assert_eq!(directive.name, "teams");
     assert_eq!(directive.clauses.len(), 3);
     assert_eq!(directive.clauses[0].name, "num_teams");
-    assert_eq!(directive.clauses[0].kind, ClauseKind::Parenthesized("8"));
+    assert_eq!(
+        directive.clauses[0].kind,
+        ClauseKind::Parenthesized("8".into())
+    );
     assert_eq!(directive.clauses[1].name, "thread_limit");
-    assert_eq!(directive.clauses[1].kind, ClauseKind::Parenthesized("32"));
+    assert_eq!(
+        directive.clauses[1].kind,
+        ClauseKind::Parenthesized("32".into())
+    );
     assert_eq!(directive.clauses[2].name, "reduction");
     assert_eq!(
         directive.clauses[2].kind,
-        ClauseKind::Parenthesized("+:total")
+        ClauseKind::Parenthesized("+:total".into())
     );
 }
 
@@ -32,16 +38,19 @@ fn parses_teams_distribute_parallel_loop() {
     assert_eq!(directive.name, "teams distribute parallel loop");
     assert_eq!(directive.clauses.len(), 3);
     assert_eq!(directive.clauses[0].name, "collapse");
-    assert_eq!(directive.clauses[0].kind, ClauseKind::Parenthesized("3"));
+    assert_eq!(
+        directive.clauses[0].kind,
+        ClauseKind::Parenthesized("3".into())
+    );
     assert_eq!(directive.clauses[1].name, "allocate");
     assert_eq!(
         directive.clauses[1].kind,
-        ClauseKind::Parenthesized("pmem:buf")
+        ClauseKind::Parenthesized("pmem:buf".into())
     );
     assert_eq!(directive.clauses[2].name, "order");
     assert_eq!(
         directive.clauses[2].kind,
-        ClauseKind::Parenthesized("concurrent")
+        ClauseKind::Parenthesized("concurrent".into())
     );
 }
 
@@ -54,8 +63,11 @@ fn parses_teams_distribute_with_dist_schedule() {
     assert_eq!(directive.clauses[0].name, "dist_schedule");
     assert_eq!(
         directive.clauses[0].kind,
-        ClauseKind::Parenthesized("static,4"),
+        ClauseKind::Parenthesized("static,4".into()),
     );
     assert_eq!(directive.clauses[1].name, "collapse");
-    assert_eq!(directive.clauses[1].kind, ClauseKind::Parenthesized("2"));
+    assert_eq!(
+        directive.clauses[1].kind,
+        ClauseKind::Parenthesized("2".into())
+    );
 }

--- a/utils/tester.rs
+++ b/utils/tester.rs
@@ -9,7 +9,7 @@ fn main() {
             for clause in directive.clauses {
                 match clause.kind {
                     ClauseKind::Bare => println!("Clause: {}", clause.name),
-                    ClauseKind::Parenthesized(value) => {
+                    ClauseKind::Parenthesized(ref value) => {
                         println!("Clause: {}({})", clause.name, value);
                     }
                 }


### PR DESCRIPTION
## Summary
- collapse OpenMP continuation markers during lexing and update directive/clause parsing to normalize names with `Cow`
- adjust IR, C API, and existing tests to the new clause representation
- document continuation behavior and add dedicated unit, integration, and ompparser compatibility tests

## Testing
- cargo test
- (cd compat/ompparser/build && ctest)


------
https://chatgpt.com/codex/tasks/task_e_68ed19d35480832fba9c18b091cc114b