### PR TITLE
Fix directive continuation prefix detection (#30)

### DIFF
--- a/src/parser/directive.rs
+++ b/src/parser/directive.rs
@@ -180,9 +180,9 @@ impl DirectiveRegistry {
             if let Some((_, next_ch)) = input[idx..].char_indices().next() {
                 if is_ident_char(next_ch) {
                     // check if prefix is registered; if so, continue to extend
-                    let prefix_candidate = input[start..idx].trim_end();
+                    let prefix_candidate_slice = &input[start..idx];
                     let prefix_candidate =
-                        crate::lexer::collapse_line_continuations(prefix_candidate);
+                        crate::lexer::collapse_line_continuations(prefix_candidate_slice);
                     let prefix_candidate_ref = prefix_candidate.as_ref().trim_end();
                     // Check for prefixes
                     let has_prefix = if self.case_insensitive {


### PR DESCRIPTION
## Summary
- avoid trimming away newline context before collapsing continuation markers when checking directive prefixes
- re-enable and extend line continuation integration tests covering split directive names in C and Fortran

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f192fb18b4832f8dc2390a0da7d9c4