### PR TITLE
Add comprehensive Fortran sentinel tests

### DIFF
--- a/docs/book/src/openmp-support.md
+++ b/docs/book/src/openmp-support.md
@@ -296,7 +296,7 @@ end do
 !$omp end parallel do
 ```
 
-✅ **Supported:** Free-form (`!$omp`), Fixed-form (`c$omp`, `*$omp`)  
+✅ **Supported:** Free-form (`!$omp`), Fixed-form (`!$omp`, `!$`, `c$omp`, `c$`, `*$omp`, `*$`)
 ✅ **Case insensitive:** `!$OMP`, `!$Omp`, `!$omp` all work
 
 ---

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -97,7 +97,11 @@ pub fn lex_fortran_free_sentinel(input: &str) -> IResult<&str, &str> {
     }
 }
 
-/// Parse Fortran fixed-form sentinel "!$OMP" or "C$OMP" in columns 1-6 (case-insensitive)
+/// Parse Fortran fixed-form sentinel variants (case-insensitive)
+///
+/// Supported sentinels in columns 1-6:
+/// - Long form: `!$OMP`, `C$OMP`, `*$OMP`
+/// - Short form: `!$`, `C$`, `*$` (often used on continuation lines)
 ///
 /// Supports leading whitespace before the sentinel:
 /// - "!$OMP PARALLEL" -> matches
@@ -108,16 +112,8 @@ pub fn lex_fortran_fixed_sentinel(input: &str) -> IResult<&str, &str> {
     // Skip optional leading whitespace (common in indented Fortran code)
     let (after_space, _) = skip_space_and_comments(input)?;
 
-    // Optimize: check only first 5 characters instead of entire input
-    let first_5 = after_space.get(..5);
-    let matches = first_5.map_or(false, |s| {
-        s.eq_ignore_ascii_case("!$omp")
-            || s.eq_ignore_ascii_case("c$omp")
-            || s.eq_ignore_ascii_case("*$omp")
-    });
-
-    if matches {
-        Ok((&after_space[5..], &after_space[..5]))
+    if let Some(len) = match_fortran_sentinel(after_space) {
+        Ok((&after_space[len..], &after_space[..len]))
     } else {
         Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -431,7 +427,9 @@ fn skip_fortran_continuation(input: &str, idx: usize) -> Option<usize> {
 }
 
 fn match_fortran_sentinel(input: &str) -> Option<usize> {
-    let candidates = ["!$omp", "c$omp", "*$omp"];
+    // Order matters: check long-form sentinels before short-form variants so we
+    // always prefer the most specific match when both could apply.
+    let candidates = ["!$omp", "c$omp", "*$omp", "!$", "c$", "*$"];
     for candidate in candidates {
         if input.len() >= candidate.len()
             && input[..candidate.len()].eq_ignore_ascii_case(candidate)

--- a/tests/openmp_fortran_sentinels.rs
+++ b/tests/openmp_fortran_sentinels.rs
@@ -1,0 +1,227 @@
+use roup::lexer::Language;
+use roup::parser::{ClauseKind, Directive, Parser};
+
+fn parse_fixed(input: &str) -> Directive<'_> {
+    let parser = Parser::default().with_language(Language::FortranFixed);
+    let (_, directive) = parser.parse(input).expect("directive should parse");
+    directive
+}
+
+fn parse_free(input: &str) -> Directive<'_> {
+    let parser = Parser::default().with_language(Language::FortranFree);
+    let (_, directive) = parser.parse(input).expect("directive should parse");
+    directive
+}
+
+#[test]
+fn fixed_form_supports_short_form_continuations() {
+    let directive = parse_fixed(concat!(
+        "      !$OMP PARALLEL DO &\n",
+        "      !$& PRIVATE(I) &\n",
+        "      !$& SHARED(A)"
+    ));
+
+    assert_eq!(directive.name, "parallel do");
+    assert_eq!(directive.clauses.len(), 2);
+    assert_eq!(directive.clauses[0].name, "private");
+    assert_eq!(
+        directive.clauses[0].kind,
+        ClauseKind::Parenthesized("I".into())
+    );
+    assert_eq!(directive.clauses[1].name, "shared");
+    assert_eq!(
+        directive.clauses[1].kind,
+        ClauseKind::Parenthesized("A".into())
+    );
+}
+
+#[test]
+fn fixed_form_supports_alternate_comment_characters() {
+    for sentinel in ["C$OMP", "C$", "*$OMP", "*$"] {
+        let source = format!(
+            "      {sentinel} TEAMS DISTRIBUTE &\n      {sentinel}& PARALLEL DO &\n      {sentinel}& PRIVATE(I)",
+        );
+        let directive = parse_fixed(&source);
+
+        assert_eq!(directive.name, "teams distribute parallel do");
+        assert_eq!(directive.clauses.len(), 1);
+        assert_eq!(directive.clauses[0].name, "private");
+        assert_eq!(
+            directive.clauses[0].kind,
+            ClauseKind::Parenthesized("I".into())
+        );
+    }
+}
+
+#[test]
+fn fixed_form_accepts_short_sentinel_on_initial_line() {
+    let directive = parse_fixed(concat!("      !$ PARALLEL DO &\n", "      !$& PRIVATE(I)"));
+
+    assert_eq!(directive.name, "parallel do");
+    assert_eq!(directive.clauses.len(), 1);
+    assert_eq!(directive.clauses[0].name, "private");
+    assert_eq!(
+        directive.clauses[0].kind,
+        ClauseKind::Parenthesized("I".into())
+    );
+}
+
+#[test]
+fn fixed_form_is_case_insensitive_for_sentinels() {
+    let directive = parse_fixed(concat!(
+        "      !$Omp TEAMS DISTRIBUTE &\n",
+        "      !$oMP& PARALLEL DO &\n",
+        "      !$OmP& PRIVATE(I)"
+    ));
+
+    assert_eq!(directive.name, "teams distribute parallel do");
+    assert_eq!(directive.clauses.len(), 1);
+    assert_eq!(directive.clauses[0].name, "private");
+}
+
+#[test]
+fn free_form_accepts_leading_ampersand_on_continuation_line() {
+    let directive = parse_free(concat!("!$omp parallel do &\n", "& private(i, j)"));
+
+    assert_eq!(directive.name, "parallel do");
+    assert_eq!(directive.clauses.len(), 1);
+    assert_eq!(directive.clauses[0].name, "private");
+    assert_eq!(
+        directive.clauses[0].kind,
+        ClauseKind::Parenthesized("i, j".into())
+    );
+}
+
+#[test]
+fn free_form_accepts_ampersand_at_both_ends() {
+    let directive = parse_free(concat!(
+        "!$omp parallel do &\n",
+        "!$omp& private(i, &\n",
+        "!$omp& j)"
+    ));
+
+    assert_eq!(directive.name, "parallel do");
+    assert_eq!(directive.clauses.len(), 1);
+    assert_eq!(directive.clauses[0].name, "private");
+    assert_eq!(
+        directive.clauses[0].kind,
+        ClauseKind::Parenthesized("i, j".into())
+    );
+}
+
+#[test]
+fn free_form_supports_multiple_consecutive_continuations() {
+    let directive = parse_free(concat!(
+        "!$omp target teams distribute &\n",
+        "!$omp& parallel do &\n",
+        "!$omp& schedule(dynamic) &\n",
+        "!$omp& private(i, j)"
+    ));
+
+    assert_eq!(directive.name, "target teams distribute parallel do");
+    assert_eq!(directive.clauses.len(), 2);
+    assert_eq!(directive.clauses[0].name, "schedule");
+    assert_eq!(
+        directive.clauses[0].kind,
+        ClauseKind::Parenthesized("dynamic".into())
+    );
+    assert_eq!(directive.clauses[1].name, "private");
+}
+
+#[test]
+fn free_form_handles_varying_indentation() {
+    let directive = parse_free(concat!(
+        "    !$omp parallel do &\n",
+        "          !$omp& private(i) &\n",
+        "!$omp& shared(a)"
+    ));
+
+    assert_eq!(directive.name, "parallel do");
+    assert_eq!(directive.clauses.len(), 2);
+    assert_eq!(directive.clauses[0].name, "private");
+    assert_eq!(directive.clauses[1].name, "shared");
+}
+
+#[test]
+fn free_form_continuation_inside_directive_name() {
+    let directive = parse_free(concat!("!$omp parallel&\n", "!$omp& do schedule(static)"));
+
+    assert_eq!(directive.name, "parallel do");
+    assert_eq!(directive.clauses.len(), 1);
+    assert_eq!(directive.clauses[0].name, "schedule");
+}
+
+#[test]
+fn free_form_continuation_inside_clause() {
+    let directive = parse_free(concat!(
+        "!$omp parallel do private(&\n",
+        "!$omp& x, &\n",
+        "!$omp& y)"
+    ));
+
+    assert_eq!(directive.clauses.len(), 1);
+    assert_eq!(directive.clauses[0].name, "private");
+    assert_eq!(
+        directive.clauses[0].kind,
+        ClauseKind::Parenthesized("x, y".into())
+    );
+}
+
+#[test]
+fn free_form_allows_empty_continuation_lines() {
+    let directive = parse_free(concat!(
+        "!$omp parallel do &\n",
+        "!$omp& &\n",
+        "!$omp& private(i)"
+    ));
+
+    assert_eq!(directive.name, "parallel do");
+    assert_eq!(directive.clauses.len(), 1);
+}
+
+#[test]
+fn free_form_skips_comment_only_continuation_lines() {
+    let directive = parse_free(concat!(
+        "!$omp parallel do &\n",
+        "!$omp& & ! comment about variables\n",
+        "!$omp& private(i, j)"
+    ));
+
+    assert_eq!(directive.clauses.len(), 1);
+    assert_eq!(directive.clauses[0].name, "private");
+}
+
+#[test]
+fn free_form_respects_maximum_continuation_depth() {
+    let directive = parse_free(concat!(
+        "!$omp parallel do &\n",
+        "!$omp& private(i, &\n",
+        "!$omp& j, &\n",
+        "!$omp& k, &\n",
+        "!$omp& l)"
+    ));
+
+    assert_eq!(directive.clauses.len(), 1);
+    assert_eq!(directive.clauses[0].name, "private");
+    assert_eq!(
+        directive.clauses[0].kind,
+        ClauseKind::Parenthesized("i, j, k, l".into())
+    );
+}
+
+#[test]
+fn free_form_errors_on_inline_ampersand_without_newline() {
+    let parser = Parser::default().with_language(Language::FortranFree);
+    match parser.parse("!$omp parallel do & private(i)") {
+        Ok((rest, directive)) => {
+            assert!(
+                rest.starts_with("&"),
+                "expected inline ampersand to remain, got {rest:?}"
+            );
+            assert!(directive.clauses.is_empty());
+        }
+        Err(err) => {
+            panic!("expected parser to leave inline ampersand unparsed, got error: {err:?}")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend Fortran fixed-form sentinel detection to cover short comment-prefixed variants
- add extensive Fortran continuation tests exercising sentinel, indentation, and edge cases
- document the expanded set of supported fixed-form sentinels in the book

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f192fb18b4832f8dc2390a0da7d9c4