### PR TITLE
Add C-to-Fortran directive translation support

### DIFF
--- a/compat/ompparser/src/compat_impl.cpp
+++ b/compat/ompparser/src/compat_impl.cpp
@@ -28,6 +28,7 @@ extern "C" {
 
     // Core parsing
     OmpDirective* roup_parse(const char* input);
+    OmpDirective* roup_parse_with_language(const char* input, int32_t language);
     void roup_directive_free(OmpDirective* directive);
 
     // Directive queries
@@ -149,8 +150,17 @@ OpenMPDirective* parseOpenMP(const char* input, void* exprParse(const char* expr
         }
     }
 
-    // Call ROUP parser
-    OmpDirective* roup_dir = roup_parse(input_str.c_str());
+    // Call ROUP parser with language-aware mode for Fortran
+    OmpDirective* roup_dir = nullptr;
+    if (current_lang == Lang_Fortran) {
+        roup_dir = roup_parse_with_language(input_str.c_str(), ROUP_LANG_FORTRAN_FREE);
+        if (!roup_dir) {
+            // Fallback to language-neutral parse for mixed inputs (e.g., #pragma strings)
+            roup_dir = roup_parse(input_str.c_str());
+        }
+    } else {
+        roup_dir = roup_parse(input_str.c_str());
+    }
     if (!roup_dir) {
         return nullptr;
     }

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -13,6 +13,7 @@
 - [C Tutorial](./c-tutorial.md)
 - [C++ Tutorial](./cpp-tutorial.md)
 - [Fortran Tutorial](./fortran-tutorial.md)
+- [C to Fortran Translation](./c-to-fortran.md)
 - [ompparser Compatibility](./ompparser-compat.md)
 
 # Reference

--- a/docs/book/src/c-to-fortran.md
+++ b/docs/book/src/c-to-fortran.md
@@ -1,0 +1,79 @@
+# C to Fortran Directive Translation
+
+OpenMP toolchains often need both C/C++ **and** Fortran versions of the same
+benchmark. ROUP can now take a directive parsed from C/C++ syntax and emit a
+Fortran equivalent without reparsing the source code.
+
+## When to Use
+
+- Generating Fortran test cases from existing C benchmarks
+- Normalising mixed-language code bases to a single style
+- Porting ompparser-driven tooling to ROUP while preserving Fortran output
+
+## Quick Example
+
+```rust
+use roup::ir::{convert::convert_directive, Language, ParserConfig, SourceLocation};
+use roup::parser::parse_omp_directive;
+
+let input = "#pragma omp parallel for schedule(dynamic, 4)";
+let (_, directive) = parse_omp_directive(input).unwrap();
+let config = ParserConfig::default();
+
+// Tell the IR layer to emit Fortran
+let ir = convert_directive(&directive, SourceLocation::start(), Language::Fortran, &config)
+    .unwrap();
+
+assert_eq!(ir.to_string(), "!$omp parallel do schedule(dynamic, 4)");
+```
+
+The parser still sees the original C syntax. By selecting `Language::Fortran`
+when constructing the IR (or later via `DirectiveIR::with_language`), the
+Display implementation substitutes Fortran spellings:
+
+| Canonical Kind | C/C++ Output                | Fortran Output                    |
+|----------------|-----------------------------|-----------------------------------|
+| `parallel for` | `#pragma omp parallel for`  | `!$omp parallel do`               |
+| `for`          | `#pragma omp for`           | `!$omp do`                        |
+| `teams distribute parallel for` | `#pragma omp teams distribute parallel for` | `!$omp teams distribute parallel do` |
+
+## Translating Existing IR
+
+Already have a `DirectiveIR` from C code? Flip the language in place or return a
+new value:
+
+```rust
+use roup::ir::{DirectiveIR, DirectiveKind, Language, SourceLocation};
+
+let mut ir = DirectiveIR::simple(
+    DirectiveKind::ParallelFor,
+    "parallel for",
+    SourceLocation::start(),
+    Language::C,
+);
+
+ir.set_language(Language::Fortran);
+assert_eq!(ir.to_string(), "!$omp parallel do");
+
+let teams = DirectiveIR::simple(
+    DirectiveKind::TeamsDistributeParallelFor,
+    "teams distribute parallel for",
+    SourceLocation::start(),
+    Language::C,
+)
+.with_language(Language::Fortran);
+
+assert_eq!(teams.to_string(), "!$omp teams distribute parallel do");
+```
+
+## Compatibility Layer
+
+The ompparser compatibility shim inherits the new behaviour automatically. Any
+caller that sets the base language to Fortran now receives Fortran-prefixed
+strings even when the original input used `omp ...` tokens.
+
+## Next Steps
+
+- Combine with [`Parser::with_language`](./fortran-tutorial.md) for full
+  Fortran parsing.
+- Feed the translated strings into ROSE or other Fortran-aware toolchains.

--- a/src/ir/convert.rs
+++ b/src/ir/convert.rs
@@ -104,6 +104,8 @@ pub fn parse_directive_kind(name: &str) -> Result<DirectiveKind, ConversionError
         "parallel" => Ok(DirectiveKind::Parallel),
         "parallel for" => Ok(DirectiveKind::ParallelFor),
         "parallel for simd" => Ok(DirectiveKind::ParallelForSimd),
+        "parallel do" => Ok(DirectiveKind::ParallelFor),
+        "parallel do simd" => Ok(DirectiveKind::ParallelForSimd),
         "parallel sections" => Ok(DirectiveKind::ParallelSections),
         "parallel workshare" => Ok(DirectiveKind::ParallelWorkshare),
         "parallel loop" => Ok(DirectiveKind::ParallelLoop),
@@ -113,6 +115,8 @@ pub fn parse_directive_kind(name: &str) -> Result<DirectiveKind, ConversionError
         // Work-sharing constructs
         "for" => Ok(DirectiveKind::For),
         "for simd" => Ok(DirectiveKind::ForSimd),
+        "do" => Ok(DirectiveKind::For),
+        "do simd" => Ok(DirectiveKind::ForSimd),
         "sections" => Ok(DirectiveKind::Sections),
         "section" => Ok(DirectiveKind::Section),
         "single" => Ok(DirectiveKind::Single),
@@ -140,6 +144,8 @@ pub fn parse_directive_kind(name: &str) -> Result<DirectiveKind, ConversionError
         "target parallel" => Ok(DirectiveKind::TargetParallel),
         "target parallel for" => Ok(DirectiveKind::TargetParallelFor),
         "target parallel for simd" => Ok(DirectiveKind::TargetParallelForSimd),
+        "target parallel do" => Ok(DirectiveKind::TargetParallelFor),
+        "target parallel do simd" => Ok(DirectiveKind::TargetParallelForSimd),
         "target parallel loop" => Ok(DirectiveKind::TargetParallelLoop),
         "target simd" => Ok(DirectiveKind::TargetSimd),
         "target teams" => Ok(DirectiveKind::TargetTeams),
@@ -151,6 +157,12 @@ pub fn parse_directive_kind(name: &str) -> Result<DirectiveKind, ConversionError
         "target teams distribute parallel for simd" => {
             Ok(DirectiveKind::TargetTeamsDistributeParallelForSimd)
         }
+        "target teams distribute parallel do" => {
+            Ok(DirectiveKind::TargetTeamsDistributeParallelFor)
+        }
+        "target teams distribute parallel do simd" => {
+            Ok(DirectiveKind::TargetTeamsDistributeParallelForSimd)
+        }
         "target teams loop" => Ok(DirectiveKind::TargetTeamsLoop),
 
         // Teams constructs
@@ -159,6 +171,8 @@ pub fn parse_directive_kind(name: &str) -> Result<DirectiveKind, ConversionError
         "teams distribute simd" => Ok(DirectiveKind::TeamsDistributeSimd),
         "teams distribute parallel for" => Ok(DirectiveKind::TeamsDistributeParallelFor),
         "teams distribute parallel for simd" => Ok(DirectiveKind::TeamsDistributeParallelForSimd),
+        "teams distribute parallel do" => Ok(DirectiveKind::TeamsDistributeParallelFor),
+        "teams distribute parallel do simd" => Ok(DirectiveKind::TeamsDistributeParallelForSimd),
         "teams loop" => Ok(DirectiveKind::TeamsLoop),
 
         // Synchronization constructs
@@ -181,6 +195,8 @@ pub fn parse_directive_kind(name: &str) -> Result<DirectiveKind, ConversionError
         "distribute simd" => Ok(DirectiveKind::DistributeSimd),
         "distribute parallel for" => Ok(DirectiveKind::DistributeParallelFor),
         "distribute parallel for simd" => Ok(DirectiveKind::DistributeParallelForSimd),
+        "distribute parallel do" => Ok(DirectiveKind::DistributeParallelFor),
+        "distribute parallel do simd" => Ok(DirectiveKind::DistributeParallelForSimd),
 
         // Meta-directives
         "metadirective" => Ok(DirectiveKind::Metadirective),
@@ -779,6 +795,23 @@ mod tests {
         assert_eq!(
             parse_directive_kind("parallel for").unwrap(),
             DirectiveKind::ParallelFor
+        );
+    }
+
+    #[test]
+    fn test_parse_directive_kind_fortran_variants() {
+        assert_eq!(
+            parse_directive_kind("parallel do").unwrap(),
+            DirectiveKind::ParallelFor
+        );
+        assert_eq!(parse_directive_kind("do").unwrap(), DirectiveKind::For);
+        assert_eq!(
+            parse_directive_kind("teams distribute parallel do").unwrap(),
+            DirectiveKind::TeamsDistributeParallelFor
+        );
+        assert_eq!(
+            parse_directive_kind("target parallel do simd").unwrap(),
+            DirectiveKind::TargetParallelForSimd
         );
     }
 

--- a/src/ir/directive.rs
+++ b/src/ir/directive.rs
@@ -255,115 +255,136 @@ pub enum DirectiveKind {
     Unknown = 255,
 }
 
-impl fmt::Display for DirectiveKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl DirectiveKind {
+    /// Canonical OpenMP directive name used for C/C++ output and normalization.
+    pub const fn canonical_name(self) -> &'static str {
         match self {
             // Parallel constructs
-            DirectiveKind::Parallel => write!(f, "parallel"),
-            DirectiveKind::ParallelFor => write!(f, "parallel for"),
-            DirectiveKind::ParallelForSimd => write!(f, "parallel for simd"),
-            DirectiveKind::ParallelSections => write!(f, "parallel sections"),
-            DirectiveKind::ParallelWorkshare => write!(f, "parallel workshare"),
-            DirectiveKind::ParallelLoop => write!(f, "parallel loop"),
-            DirectiveKind::ParallelMasked => write!(f, "parallel masked"),
-            DirectiveKind::ParallelMaster => write!(f, "parallel master"),
+            DirectiveKind::Parallel => "parallel",
+            DirectiveKind::ParallelFor => "parallel for",
+            DirectiveKind::ParallelForSimd => "parallel for simd",
+            DirectiveKind::ParallelSections => "parallel sections",
+            DirectiveKind::ParallelWorkshare => "parallel workshare",
+            DirectiveKind::ParallelLoop => "parallel loop",
+            DirectiveKind::ParallelMasked => "parallel masked",
+            DirectiveKind::ParallelMaster => "parallel master",
 
             // Work-sharing constructs
-            DirectiveKind::For => write!(f, "for"),
-            DirectiveKind::ForSimd => write!(f, "for simd"),
-            DirectiveKind::Sections => write!(f, "sections"),
-            DirectiveKind::Section => write!(f, "section"),
-            DirectiveKind::Single => write!(f, "single"),
-            DirectiveKind::Workshare => write!(f, "workshare"),
-            DirectiveKind::Loop => write!(f, "loop"),
+            DirectiveKind::For => "for",
+            DirectiveKind::ForSimd => "for simd",
+            DirectiveKind::Sections => "sections",
+            DirectiveKind::Section => "section",
+            DirectiveKind::Single => "single",
+            DirectiveKind::Workshare => "workshare",
+            DirectiveKind::Loop => "loop",
 
             // SIMD constructs
-            DirectiveKind::Simd => write!(f, "simd"),
-            DirectiveKind::DeclareSimd => write!(f, "declare simd"),
+            DirectiveKind::Simd => "simd",
+            DirectiveKind::DeclareSimd => "declare simd",
 
             // Task constructs
-            DirectiveKind::Task => write!(f, "task"),
-            DirectiveKind::Taskloop => write!(f, "taskloop"),
-            DirectiveKind::TaskloopSimd => write!(f, "taskloop simd"),
-            DirectiveKind::Taskyield => write!(f, "taskyield"),
-            DirectiveKind::Taskwait => write!(f, "taskwait"),
-            DirectiveKind::Taskgroup => write!(f, "taskgroup"),
+            DirectiveKind::Task => "task",
+            DirectiveKind::Taskloop => "taskloop",
+            DirectiveKind::TaskloopSimd => "taskloop simd",
+            DirectiveKind::Taskyield => "taskyield",
+            DirectiveKind::Taskwait => "taskwait",
+            DirectiveKind::Taskgroup => "taskgroup",
 
             // Target constructs
-            DirectiveKind::Target => write!(f, "target"),
-            DirectiveKind::TargetData => write!(f, "target data"),
-            DirectiveKind::TargetEnterData => write!(f, "target enter data"),
-            DirectiveKind::TargetExitData => write!(f, "target exit data"),
-            DirectiveKind::TargetUpdate => write!(f, "target update"),
-            DirectiveKind::TargetParallel => write!(f, "target parallel"),
-            DirectiveKind::TargetParallelFor => write!(f, "target parallel for"),
-            DirectiveKind::TargetParallelForSimd => write!(f, "target parallel for simd"),
-            DirectiveKind::TargetParallelLoop => write!(f, "target parallel loop"),
-            DirectiveKind::TargetSimd => write!(f, "target simd"),
-            DirectiveKind::TargetTeams => write!(f, "target teams"),
-            DirectiveKind::TargetTeamsDistribute => write!(f, "target teams distribute"),
-            DirectiveKind::TargetTeamsDistributeSimd => write!(f, "target teams distribute simd"),
+            DirectiveKind::Target => "target",
+            DirectiveKind::TargetData => "target data",
+            DirectiveKind::TargetEnterData => "target enter data",
+            DirectiveKind::TargetExitData => "target exit data",
+            DirectiveKind::TargetUpdate => "target update",
+            DirectiveKind::TargetParallel => "target parallel",
+            DirectiveKind::TargetParallelFor => "target parallel for",
+            DirectiveKind::TargetParallelForSimd => "target parallel for simd",
+            DirectiveKind::TargetParallelLoop => "target parallel loop",
+            DirectiveKind::TargetSimd => "target simd",
+            DirectiveKind::TargetTeams => "target teams",
+            DirectiveKind::TargetTeamsDistribute => "target teams distribute",
+            DirectiveKind::TargetTeamsDistributeSimd => "target teams distribute simd",
             DirectiveKind::TargetTeamsDistributeParallelFor => {
-                write!(f, "target teams distribute parallel for")
+                "target teams distribute parallel for"
             }
             DirectiveKind::TargetTeamsDistributeParallelForSimd => {
-                write!(f, "target teams distribute parallel for simd")
+                "target teams distribute parallel for simd"
             }
-            DirectiveKind::TargetTeamsLoop => write!(f, "target teams loop"),
+            DirectiveKind::TargetTeamsLoop => "target teams loop",
 
             // Teams constructs
-            DirectiveKind::Teams => write!(f, "teams"),
-            DirectiveKind::TeamsDistribute => write!(f, "teams distribute"),
-            DirectiveKind::TeamsDistributeSimd => write!(f, "teams distribute simd"),
-            DirectiveKind::TeamsDistributeParallelFor => {
-                write!(f, "teams distribute parallel for")
-            }
-            DirectiveKind::TeamsDistributeParallelForSimd => {
-                write!(f, "teams distribute parallel for simd")
-            }
-            DirectiveKind::TeamsLoop => write!(f, "teams loop"),
+            DirectiveKind::Teams => "teams",
+            DirectiveKind::TeamsDistribute => "teams distribute",
+            DirectiveKind::TeamsDistributeSimd => "teams distribute simd",
+            DirectiveKind::TeamsDistributeParallelFor => "teams distribute parallel for",
+            DirectiveKind::TeamsDistributeParallelForSimd => "teams distribute parallel for simd",
+            DirectiveKind::TeamsLoop => "teams loop",
 
             // Synchronization constructs
-            DirectiveKind::Barrier => write!(f, "barrier"),
-            DirectiveKind::Critical => write!(f, "critical"),
-            DirectiveKind::Atomic => write!(f, "atomic"),
-            DirectiveKind::Flush => write!(f, "flush"),
-            DirectiveKind::Ordered => write!(f, "ordered"),
-            DirectiveKind::Master => write!(f, "master"),
-            DirectiveKind::Masked => write!(f, "masked"),
+            DirectiveKind::Barrier => "barrier",
+            DirectiveKind::Critical => "critical",
+            DirectiveKind::Atomic => "atomic",
+            DirectiveKind::Flush => "flush",
+            DirectiveKind::Ordered => "ordered",
+            DirectiveKind::Master => "master",
+            DirectiveKind::Masked => "masked",
 
             // Declare constructs
-            DirectiveKind::DeclareReduction => write!(f, "declare reduction"),
-            DirectiveKind::DeclareMapper => write!(f, "declare mapper"),
-            DirectiveKind::DeclareTarget => write!(f, "declare target"),
-            DirectiveKind::DeclareVariant => write!(f, "declare variant"),
+            DirectiveKind::DeclareReduction => "declare reduction",
+            DirectiveKind::DeclareMapper => "declare mapper",
+            DirectiveKind::DeclareTarget => "declare target",
+            DirectiveKind::DeclareVariant => "declare variant",
 
             // Distribute constructs
-            DirectiveKind::Distribute => write!(f, "distribute"),
-            DirectiveKind::DistributeSimd => write!(f, "distribute simd"),
-            DirectiveKind::DistributeParallelFor => write!(f, "distribute parallel for"),
-            DirectiveKind::DistributeParallelForSimd => {
-                write!(f, "distribute parallel for simd")
-            }
+            DirectiveKind::Distribute => "distribute",
+            DirectiveKind::DistributeSimd => "distribute simd",
+            DirectiveKind::DistributeParallelFor => "distribute parallel for",
+            DirectiveKind::DistributeParallelForSimd => "distribute parallel for simd",
 
             // Meta-directives
-            DirectiveKind::Metadirective => write!(f, "metadirective"),
+            DirectiveKind::Metadirective => "metadirective",
 
             // Other constructs
-            DirectiveKind::Threadprivate => write!(f, "threadprivate"),
-            DirectiveKind::Allocate => write!(f, "allocate"),
-            DirectiveKind::Requires => write!(f, "requires"),
-            DirectiveKind::Scan => write!(f, "scan"),
-            DirectiveKind::Depobj => write!(f, "depobj"),
-            DirectiveKind::Nothing => write!(f, "nothing"),
-            DirectiveKind::Error => write!(f, "error"),
+            DirectiveKind::Threadprivate => "threadprivate",
+            DirectiveKind::Allocate => "allocate",
+            DirectiveKind::Requires => "requires",
+            DirectiveKind::Scan => "scan",
+            DirectiveKind::Depobj => "depobj",
+            DirectiveKind::Nothing => "nothing",
+            DirectiveKind::Error => "error",
 
-            DirectiveKind::Unknown => write!(f, "unknown"),
+            DirectiveKind::Unknown => "unknown",
         }
     }
-}
 
-impl DirectiveKind {
+    /// Language-specific display name.
+    pub const fn display_name(self, language: Language) -> &'static str {
+        match language {
+            Language::Fortran => match self {
+                DirectiveKind::For => "do",
+                DirectiveKind::ForSimd => "do simd",
+                DirectiveKind::ParallelFor => "parallel do",
+                DirectiveKind::ParallelForSimd => "parallel do simd",
+                DirectiveKind::DistributeParallelFor => "distribute parallel do",
+                DirectiveKind::DistributeParallelForSimd => "distribute parallel do simd",
+                DirectiveKind::TargetParallelFor => "target parallel do",
+                DirectiveKind::TargetParallelForSimd => "target parallel do simd",
+                DirectiveKind::TargetTeamsDistributeParallelFor => {
+                    "target teams distribute parallel do"
+                }
+                DirectiveKind::TargetTeamsDistributeParallelForSimd => {
+                    "target teams distribute parallel do simd"
+                }
+                DirectiveKind::TeamsDistributeParallelFor => "teams distribute parallel do",
+                DirectiveKind::TeamsDistributeParallelForSimd => {
+                    "teams distribute parallel do simd"
+                }
+                _ => self.canonical_name(),
+            },
+            _ => self.canonical_name(),
+        }
+    }
+
     /// Check if this is a parallel construct
     pub fn is_parallel(&self) -> bool {
         matches!(
@@ -536,6 +557,12 @@ impl DirectiveKind {
                 | DirectiveKind::Error
                 | DirectiveKind::Section
         )
+    }
+}
+
+impl fmt::Display for DirectiveKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.canonical_name())
     }
 }
 
@@ -809,6 +836,17 @@ impl<'a> DirectiveIR {
         self.language
     }
 
+    /// Update the language of this directive in place.
+    pub fn set_language(&mut self, language: Language) {
+        self.language = language;
+    }
+
+    /// Return a new directive with the specified language.
+    pub fn with_language(mut self, language: Language) -> Self {
+        self.language = language;
+        self
+    }
+
     /// Check if this directive has a specific clause type
     ///
     /// ## Example
@@ -861,7 +899,12 @@ impl<'a> DirectiveIR {
 impl<'a> fmt::Display for DirectiveIR {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Write pragma prefix (already includes "omp ")
-        write!(f, "{}{}", self.language.pragma_prefix(), self.kind)?;
+        write!(
+            f,
+            "{}{}",
+            self.language.pragma_prefix(),
+            self.kind.display_name(self.language)
+        )?;
 
         // Write clauses
         for clause in self.clauses.iter() {
@@ -891,6 +934,23 @@ mod tests {
         assert_eq!(
             DirectiveKind::TargetTeamsDistributeParallelForSimd.to_string(),
             "target teams distribute parallel for simd"
+        );
+    }
+
+    #[test]
+    fn test_directive_kind_display_fortran_language() {
+        assert_eq!(
+            DirectiveKind::ParallelFor.display_name(Language::Fortran),
+            "parallel do"
+        );
+        assert_eq!(DirectiveKind::For.display_name(Language::Fortran), "do");
+        assert_eq!(
+            DirectiveKind::TargetParallelForSimd.display_name(Language::Fortran),
+            "target parallel do simd"
+        );
+        assert_eq!(
+            DirectiveKind::TeamsDistributeParallelFor.display_name(Language::Fortran),
+            "teams distribute parallel do"
         );
     }
 
@@ -995,6 +1055,35 @@ mod tests {
         assert_eq!(dir.clauses().len(), 0);
         assert_eq!(dir.location(), SourceLocation::new(10, 1));
         assert_eq!(dir.language(), Language::C);
+    }
+
+    #[test]
+    fn test_directive_ir_language_switching() {
+        let mut dir = DirectiveIR::simple(
+            DirectiveKind::ParallelFor,
+            "parallel for",
+            SourceLocation::start(),
+            Language::C,
+        );
+        assert_eq!(dir.to_string(), "#pragma omp parallel for");
+
+        dir.set_language(Language::Fortran);
+        assert_eq!(dir.language(), Language::Fortran);
+        assert_eq!(dir.to_string(), "!$omp parallel do");
+
+        let dir_fortran = DirectiveIR::simple(
+            DirectiveKind::TeamsDistributeParallelFor,
+            "teams distribute parallel for",
+            SourceLocation::start(),
+            Language::C,
+        )
+        .with_language(Language::Fortran);
+
+        assert_eq!(dir_fortran.language(), Language::Fortran);
+        assert_eq!(
+            dir_fortran.to_string(),
+            "!$omp teams distribute parallel do"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- teach the IR layer to emit language-specific directive names and retarget directives between C/C++ and Fortran
- accept Fortran spellings when converting parser directives and add integration coverage for C-to-Fortran round-tripping
- document the translation workflow and update the ompparser compatibility shim/tests to exercise the new behaviour

## Testing
- `cargo test`
- `cmake ..` *(fails: compat/ompparser submodule is not initialized in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee66c1e908832f82029de9a847d705