### PR TITLE
Add C to Fortran OpenMP translation support

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -20,6 +20,7 @@
 - [API Reference](./api-reference.md)
 - [OpenMP Support Matrix](./openmp-support.md)
 - [Line Continuations](./line-continuations.md)
+- [C to Fortran Unparsing](./c-to-fortran-unparsing.md)
 
 # Developer Guide
 

--- a/docs/book/src/c-to-fortran-unparsing.md
+++ b/docs/book/src/c-to-fortran-unparsing.md
@@ -1,0 +1,74 @@
+# Translating C Pragmas to Fortran Sentinels
+
+C and C++ source files use `#pragma omp` while Fortran relies on `!$omp`.
+Many OpenMP datasets – including the DataRaceBench micro benchmarks – only
+ship C versions of kernels.  To experiment with Fortran tooling you previously
+had to manually rewrite every directive.  ROUP now automates this workflow.
+
+## Quick Example
+
+```rust
+use roup::ir::translate::translate_c_to_fortran;
+
+let input = "#pragma omp parallel for private(i)";
+let output = translate_c_to_fortran(input)?;
+assert_eq!(output, "!$omp parallel do private(i)");
+# Ok::<(), roup::ir::translate::TranslationError>(())
+```
+
+The helper parses the pragma using the C lexer, converts it into the semantic
+IR and re-emits the directive with Fortran spelling rules:
+
+- `#pragma omp` → `!$omp`
+- loop constructs swap `for` for `do`
+- combined constructs (e.g. `parallel for`, `target teams distribute parallel for simd`)
+  use the appropriate Fortran synonyms.
+
+## Handling Clauses
+
+Clause spellings remain unchanged.  ROUP preserves the original clause order
+and spacing, so the translation keeps semantic intent intact while only
+adjusting the directive keyword itself.
+
+```rust
+use roup::ir::translate::translate_c_to_fortran;
+
+let input = "#pragma omp for nowait collapse(2) schedule(dynamic, chunk)";
+let output = translate_c_to_fortran(input)?;
+assert_eq!(
+    output,
+    "!$omp do nowait collapse(2) schedule(dynamic, chunk)"
+);
+# Ok::<(), roup::ir::translate::TranslationError>(())
+```
+
+## When Translation Fails
+
+`translate_c_to_fortran` returns a `TranslationError` in three situations:
+
+1. **Empty input** – nothing to translate.
+2. **Parser errors** – the directive could not be recognised as valid OpenMP.
+3. **Conversion errors** – the directive or clauses are currently unsupported
+   by ROUP's IR layer.
+
+These errors implement `std::error::Error`, so they integrate cleanly with
+common error-handling approaches such as `anyhow` or `thiserror`.
+
+## Advanced Usage
+
+If you need to customise expression parsing (for example to disable expression
+parsing entirely) call `translate_c_to_fortran_ir` directly.  It accepts an
+explicit `ParserConfig` and returns the `DirectiveIR`, letting you inspect or
+further transform the semantic representation before rendering it to text.
+
+```rust
+use roup::ir::{translate::translate_c_to_fortran_ir, Language, ParserConfig};
+
+let config = ParserConfig::string_only(Language::C);
+let directive = translate_c_to_fortran_ir("#pragma omp for", config)?;
+assert!(directive.language().is_fortran());
+# Ok::<(), roup::ir::translate::TranslationError>(())
+```
+
+This is especially useful when integrating ROUP into larger pipelines such as
+automatic benchmark converters or source-to-source translators.

--- a/src/ir/directive.rs
+++ b/src/ir/directive.rs
@@ -255,111 +255,140 @@ pub enum DirectiveKind {
     Unknown = 255,
 }
 
-impl fmt::Display for DirectiveKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl DirectiveKind {
+    /// Base (language-neutral) directive name used for C/C++ output
+    const fn base_name(self) -> &'static str {
         match self {
             // Parallel constructs
-            DirectiveKind::Parallel => write!(f, "parallel"),
-            DirectiveKind::ParallelFor => write!(f, "parallel for"),
-            DirectiveKind::ParallelForSimd => write!(f, "parallel for simd"),
-            DirectiveKind::ParallelSections => write!(f, "parallel sections"),
-            DirectiveKind::ParallelWorkshare => write!(f, "parallel workshare"),
-            DirectiveKind::ParallelLoop => write!(f, "parallel loop"),
-            DirectiveKind::ParallelMasked => write!(f, "parallel masked"),
-            DirectiveKind::ParallelMaster => write!(f, "parallel master"),
+            DirectiveKind::Parallel => "parallel",
+            DirectiveKind::ParallelFor => "parallel for",
+            DirectiveKind::ParallelForSimd => "parallel for simd",
+            DirectiveKind::ParallelSections => "parallel sections",
+            DirectiveKind::ParallelWorkshare => "parallel workshare",
+            DirectiveKind::ParallelLoop => "parallel loop",
+            DirectiveKind::ParallelMasked => "parallel masked",
+            DirectiveKind::ParallelMaster => "parallel master",
 
             // Work-sharing constructs
-            DirectiveKind::For => write!(f, "for"),
-            DirectiveKind::ForSimd => write!(f, "for simd"),
-            DirectiveKind::Sections => write!(f, "sections"),
-            DirectiveKind::Section => write!(f, "section"),
-            DirectiveKind::Single => write!(f, "single"),
-            DirectiveKind::Workshare => write!(f, "workshare"),
-            DirectiveKind::Loop => write!(f, "loop"),
+            DirectiveKind::For => "for",
+            DirectiveKind::ForSimd => "for simd",
+            DirectiveKind::Sections => "sections",
+            DirectiveKind::Section => "section",
+            DirectiveKind::Single => "single",
+            DirectiveKind::Workshare => "workshare",
+            DirectiveKind::Loop => "loop",
 
             // SIMD constructs
-            DirectiveKind::Simd => write!(f, "simd"),
-            DirectiveKind::DeclareSimd => write!(f, "declare simd"),
+            DirectiveKind::Simd => "simd",
+            DirectiveKind::DeclareSimd => "declare simd",
 
             // Task constructs
-            DirectiveKind::Task => write!(f, "task"),
-            DirectiveKind::Taskloop => write!(f, "taskloop"),
-            DirectiveKind::TaskloopSimd => write!(f, "taskloop simd"),
-            DirectiveKind::Taskyield => write!(f, "taskyield"),
-            DirectiveKind::Taskwait => write!(f, "taskwait"),
-            DirectiveKind::Taskgroup => write!(f, "taskgroup"),
+            DirectiveKind::Task => "task",
+            DirectiveKind::Taskloop => "taskloop",
+            DirectiveKind::TaskloopSimd => "taskloop simd",
+            DirectiveKind::Taskyield => "taskyield",
+            DirectiveKind::Taskwait => "taskwait",
+            DirectiveKind::Taskgroup => "taskgroup",
 
             // Target constructs
-            DirectiveKind::Target => write!(f, "target"),
-            DirectiveKind::TargetData => write!(f, "target data"),
-            DirectiveKind::TargetEnterData => write!(f, "target enter data"),
-            DirectiveKind::TargetExitData => write!(f, "target exit data"),
-            DirectiveKind::TargetUpdate => write!(f, "target update"),
-            DirectiveKind::TargetParallel => write!(f, "target parallel"),
-            DirectiveKind::TargetParallelFor => write!(f, "target parallel for"),
-            DirectiveKind::TargetParallelForSimd => write!(f, "target parallel for simd"),
-            DirectiveKind::TargetParallelLoop => write!(f, "target parallel loop"),
-            DirectiveKind::TargetSimd => write!(f, "target simd"),
-            DirectiveKind::TargetTeams => write!(f, "target teams"),
-            DirectiveKind::TargetTeamsDistribute => write!(f, "target teams distribute"),
-            DirectiveKind::TargetTeamsDistributeSimd => write!(f, "target teams distribute simd"),
+            DirectiveKind::Target => "target",
+            DirectiveKind::TargetData => "target data",
+            DirectiveKind::TargetEnterData => "target enter data",
+            DirectiveKind::TargetExitData => "target exit data",
+            DirectiveKind::TargetUpdate => "target update",
+            DirectiveKind::TargetParallel => "target parallel",
+            DirectiveKind::TargetParallelFor => "target parallel for",
+            DirectiveKind::TargetParallelForSimd => "target parallel for simd",
+            DirectiveKind::TargetParallelLoop => "target parallel loop",
+            DirectiveKind::TargetSimd => "target simd",
+            DirectiveKind::TargetTeams => "target teams",
+            DirectiveKind::TargetTeamsDistribute => "target teams distribute",
+            DirectiveKind::TargetTeamsDistributeSimd => "target teams distribute simd",
             DirectiveKind::TargetTeamsDistributeParallelFor => {
-                write!(f, "target teams distribute parallel for")
+                "target teams distribute parallel for"
             }
             DirectiveKind::TargetTeamsDistributeParallelForSimd => {
-                write!(f, "target teams distribute parallel for simd")
+                "target teams distribute parallel for simd"
             }
-            DirectiveKind::TargetTeamsLoop => write!(f, "target teams loop"),
+            DirectiveKind::TargetTeamsLoop => "target teams loop",
 
             // Teams constructs
-            DirectiveKind::Teams => write!(f, "teams"),
-            DirectiveKind::TeamsDistribute => write!(f, "teams distribute"),
-            DirectiveKind::TeamsDistributeSimd => write!(f, "teams distribute simd"),
-            DirectiveKind::TeamsDistributeParallelFor => {
-                write!(f, "teams distribute parallel for")
-            }
-            DirectiveKind::TeamsDistributeParallelForSimd => {
-                write!(f, "teams distribute parallel for simd")
-            }
-            DirectiveKind::TeamsLoop => write!(f, "teams loop"),
+            DirectiveKind::Teams => "teams",
+            DirectiveKind::TeamsDistribute => "teams distribute",
+            DirectiveKind::TeamsDistributeSimd => "teams distribute simd",
+            DirectiveKind::TeamsDistributeParallelFor => "teams distribute parallel for",
+            DirectiveKind::TeamsDistributeParallelForSimd => "teams distribute parallel for simd",
+            DirectiveKind::TeamsLoop => "teams loop",
 
             // Synchronization constructs
-            DirectiveKind::Barrier => write!(f, "barrier"),
-            DirectiveKind::Critical => write!(f, "critical"),
-            DirectiveKind::Atomic => write!(f, "atomic"),
-            DirectiveKind::Flush => write!(f, "flush"),
-            DirectiveKind::Ordered => write!(f, "ordered"),
-            DirectiveKind::Master => write!(f, "master"),
-            DirectiveKind::Masked => write!(f, "masked"),
+            DirectiveKind::Barrier => "barrier",
+            DirectiveKind::Critical => "critical",
+            DirectiveKind::Atomic => "atomic",
+            DirectiveKind::Flush => "flush",
+            DirectiveKind::Ordered => "ordered",
+            DirectiveKind::Master => "master",
+            DirectiveKind::Masked => "masked",
 
             // Declare constructs
-            DirectiveKind::DeclareReduction => write!(f, "declare reduction"),
-            DirectiveKind::DeclareMapper => write!(f, "declare mapper"),
-            DirectiveKind::DeclareTarget => write!(f, "declare target"),
-            DirectiveKind::DeclareVariant => write!(f, "declare variant"),
+            DirectiveKind::DeclareReduction => "declare reduction",
+            DirectiveKind::DeclareMapper => "declare mapper",
+            DirectiveKind::DeclareTarget => "declare target",
+            DirectiveKind::DeclareVariant => "declare variant",
 
             // Distribute constructs
-            DirectiveKind::Distribute => write!(f, "distribute"),
-            DirectiveKind::DistributeSimd => write!(f, "distribute simd"),
-            DirectiveKind::DistributeParallelFor => write!(f, "distribute parallel for"),
-            DirectiveKind::DistributeParallelForSimd => {
-                write!(f, "distribute parallel for simd")
-            }
+            DirectiveKind::Distribute => "distribute",
+            DirectiveKind::DistributeSimd => "distribute simd",
+            DirectiveKind::DistributeParallelFor => "distribute parallel for",
+            DirectiveKind::DistributeParallelForSimd => "distribute parallel for simd",
 
             // Meta-directives
-            DirectiveKind::Metadirective => write!(f, "metadirective"),
+            DirectiveKind::Metadirective => "metadirective",
 
             // Other constructs
-            DirectiveKind::Threadprivate => write!(f, "threadprivate"),
-            DirectiveKind::Allocate => write!(f, "allocate"),
-            DirectiveKind::Requires => write!(f, "requires"),
-            DirectiveKind::Scan => write!(f, "scan"),
-            DirectiveKind::Depobj => write!(f, "depobj"),
-            DirectiveKind::Nothing => write!(f, "nothing"),
-            DirectiveKind::Error => write!(f, "error"),
+            DirectiveKind::Threadprivate => "threadprivate",
+            DirectiveKind::Allocate => "allocate",
+            DirectiveKind::Requires => "requires",
+            DirectiveKind::Scan => "scan",
+            DirectiveKind::Depobj => "depobj",
+            DirectiveKind::Nothing => "nothing",
+            DirectiveKind::Error => "error",
 
-            DirectiveKind::Unknown => write!(f, "unknown"),
+            DirectiveKind::Unknown => "unknown",
         }
+    }
+
+    /// Language-aware directive name used when formatting
+    pub const fn name_for_language(self, language: Language) -> &'static str {
+        match language {
+            Language::Fortran => match self {
+                DirectiveKind::For => "do",
+                DirectiveKind::ForSimd => "do simd",
+                DirectiveKind::ParallelFor => "parallel do",
+                DirectiveKind::ParallelForSimd => "parallel do simd",
+                DirectiveKind::TargetParallelFor => "target parallel do",
+                DirectiveKind::TargetParallelForSimd => "target parallel do simd",
+                DirectiveKind::TargetTeamsDistributeParallelFor => {
+                    "target teams distribute parallel do"
+                }
+                DirectiveKind::TargetTeamsDistributeParallelForSimd => {
+                    "target teams distribute parallel do simd"
+                }
+                DirectiveKind::TeamsDistributeParallelFor => "teams distribute parallel do",
+                DirectiveKind::TeamsDistributeParallelForSimd => {
+                    "teams distribute parallel do simd"
+                }
+                DirectiveKind::DistributeParallelFor => "distribute parallel do",
+                DirectiveKind::DistributeParallelForSimd => "distribute parallel do simd",
+                _ => self.base_name(),
+            },
+            _ => self.base_name(),
+        }
+    }
+}
+
+impl fmt::Display for DirectiveKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.base_name())
     }
 }
 
@@ -809,6 +838,20 @@ impl<'a> DirectiveIR {
         self.language
     }
 
+    /// Create a new directive IR with a different language context
+    ///
+    /// This is useful when translating between host languages, e.g. when
+    /// parsing a C pragma but emitting a Fortran sentinel.
+    pub fn into_language(mut self, language: Language) -> Self {
+        self.language = language;
+        self
+    }
+
+    /// Update the language in place
+    pub fn set_language(&mut self, language: Language) {
+        self.language = language;
+    }
+
     /// Check if this directive has a specific clause type
     ///
     /// ## Example
@@ -861,7 +904,12 @@ impl<'a> DirectiveIR {
 impl<'a> fmt::Display for DirectiveIR {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Write pragma prefix (already includes "omp ")
-        write!(f, "{}{}", self.language.pragma_prefix(), self.kind)?;
+        write!(
+            f,
+            "{}{}",
+            self.language.pragma_prefix(),
+            self.kind.name_for_language(self.language)
+        )?;
 
         // Write clauses
         for clause in self.clauses.iter() {
@@ -879,7 +927,7 @@ impl<'a> fmt::Display for DirectiveIR {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ir::{ClauseItem, DefaultKind, Identifier, ReductionOperator};
+    use crate::ir::{ClauseItem, DefaultKind, Identifier, Language, ReductionOperator};
 
     // DirectiveKind tests
     #[test]
@@ -891,6 +939,27 @@ mod tests {
         assert_eq!(
             DirectiveKind::TargetTeamsDistributeParallelForSimd.to_string(),
             "target teams distribute parallel for simd"
+        );
+    }
+
+    #[test]
+    fn test_directive_kind_fortran_names() {
+        assert_eq!(
+            DirectiveKind::ParallelFor.name_for_language(Language::Fortran),
+            "parallel do"
+        );
+        assert_eq!(
+            DirectiveKind::For.name_for_language(Language::Fortran),
+            "do"
+        );
+        assert_eq!(
+            DirectiveKind::TargetTeamsDistributeParallelForSimd
+                .name_for_language(Language::Fortran),
+            "target teams distribute parallel do simd"
+        );
+        assert_eq!(
+            DirectiveKind::Teams.name_for_language(Language::Fortran),
+            "teams"
         );
     }
 

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -54,6 +54,7 @@ pub use directive::{DirectiveIR, DirectiveKind};
 pub use expression::{
     BinaryOperator, Expression, ExpressionAst, ExpressionKind, ParserConfig, UnaryOperator,
 };
+pub use translate::{translate_c_to_fortran, translate_c_to_fortran_ir, TranslationError};
 pub use types::{Language, SourceLocation};
 pub use validate::{ValidationContext, ValidationError};
 pub use variable::{ArraySection, Identifier, Variable};
@@ -63,6 +64,7 @@ mod clause;
 pub mod convert;
 mod directive;
 mod expression;
+pub mod translate;
 mod types;
 pub mod validate;
 mod variable;

--- a/src/ir/translate.rs
+++ b/src/ir/translate.rs
@@ -1,0 +1,87 @@
+//! Language translation helpers for OpenMP directives
+//!
+//! This module provides high level utilities for converting parsed OpenMP
+//! pragmas between host languages. The primary use-case today is translating
+//! C/C++ `#pragma omp` directives into their Fortran `!$omp` equivalents so
+//! existing C benchmarks can be reused by Fortran tooling.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use roup::ir::translate::translate_c_to_fortran;
+//!
+//! let output = translate_c_to_fortran("#pragma omp parallel for private(i)")?;
+//! assert_eq!(output, "!$omp parallel do private(i)");
+//! # Ok::<(), roup::ir::translate::TranslationError>(())
+//! ```
+
+use std::fmt;
+
+use super::{convert::convert_directive, DirectiveIR, Language, ParserConfig, SourceLocation};
+use crate::parser::parse_omp_directive;
+
+/// Errors that can occur while translating between host languages
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TranslationError {
+    /// Input string was empty or contained only whitespace
+    EmptyInput,
+    /// Parser failed to recognise the directive
+    ParseError(String),
+    /// Semantic conversion failed (unknown directive/clause)
+    ConversionError(super::ConversionError),
+}
+
+impl fmt::Display for TranslationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TranslationError::EmptyInput => write!(f, "input pragma is empty"),
+            TranslationError::ParseError(msg) => write!(f, "failed to parse pragma: {}", msg),
+            TranslationError::ConversionError(err) => write!(f, "conversion error: {}", err),
+        }
+    }
+}
+
+impl std::error::Error for TranslationError {}
+
+impl From<super::ConversionError> for TranslationError {
+    fn from(err: super::ConversionError) -> Self {
+        TranslationError::ConversionError(err)
+    }
+}
+
+/// Translate a C/C++ OpenMP pragma into its Fortran representation
+///
+/// This helper parses the input using ROUP's C parser, converts it into the
+/// semantic IR, switches the language to Fortran and finally renders the
+/// directive back to a string.
+pub fn translate_c_to_fortran(input: &str) -> Result<String, TranslationError> {
+    let config = ParserConfig::with_parsing(Language::C);
+    translate_c_to_fortran_ir(input, config).map(|dir| dir.to_string())
+}
+
+/// Translate a C/C++ OpenMP pragma into a Fortran `DirectiveIR`
+///
+/// `ParserConfig` is accepted explicitly so callers can reuse pre-configured
+/// expression parsing settings (for example string-only parsing).
+pub fn translate_c_to_fortran_ir(
+    input: &str,
+    config: ParserConfig,
+) -> Result<DirectiveIR, TranslationError> {
+    if input.trim().is_empty() {
+        return Err(TranslationError::EmptyInput);
+    }
+
+    let (rest, directive) = parse_omp_directive(input)
+        .map_err(|err| TranslationError::ParseError(format!("{:?}", err)))?;
+
+    if !rest.trim().is_empty() {
+        return Err(TranslationError::ParseError(format!(
+            "unparsed trailing input: {}",
+            rest.trim()
+        )));
+    }
+
+    let ir = convert_directive(&directive, SourceLocation::start(), Language::C, &config)?;
+
+    Ok(ir.into_language(Language::Fortran))
+}

--- a/tests/openmp_translation.rs
+++ b/tests/openmp_translation.rs
@@ -1,0 +1,54 @@
+//! Integration tests for translating C pragmas into Fortran sentinels
+//!
+//! The goal is to ensure language-aware rendering preserves semantic
+//! information (directive kinds and clauses) while adapting syntax to the
+//! Fortran sentinel form required by legacy toolchains.
+
+use roup::ir::{
+    translate::{translate_c_to_fortran, translate_c_to_fortran_ir, TranslationError},
+    Language, ParserConfig,
+};
+
+#[test]
+fn translates_parallel_for_to_parallel_do() {
+    let output = translate_c_to_fortran("#pragma omp parallel for private(i) schedule(static, 4)")
+        .expect("translation should succeed");
+
+    assert_eq!(output, "!$omp parallel do private(i) schedule(static, 4)");
+}
+
+#[test]
+fn translates_for_loop_to_do_nowait() {
+    let output =
+        translate_c_to_fortran("#pragma omp for nowait").expect("translation should succeed");
+
+    assert_eq!(output, "!$omp do nowait");
+}
+
+#[test]
+fn translates_target_teams_distribute_parallel_for_simd() {
+    let output =
+        translate_c_to_fortran("#pragma omp target teams distribute parallel for simd collapse(2)")
+            .expect("translation should succeed");
+
+    assert_eq!(
+        output,
+        "!$omp target teams distribute parallel do simd collapse(2)"
+    );
+}
+
+#[test]
+fn translate_ir_variant_sets_language() {
+    let config = ParserConfig::with_parsing(Language::C);
+    let ir = translate_c_to_fortran_ir("#pragma omp parallel for", config)
+        .expect("translation should succeed");
+
+    assert!(ir.language().is_fortran());
+    assert_eq!(ir.to_string(), "!$omp parallel do");
+}
+
+#[test]
+fn rejects_empty_input() {
+    let err = translate_c_to_fortran("").expect_err("empty input should error");
+    assert!(matches!(err, TranslationError::EmptyInput));
+}


### PR DESCRIPTION
## Summary
- add language-aware directive rendering with Fortran-specific names
- introduce translation helpers that convert C pragmas into Fortran sentinels with integration tests
- document the new workflow for re-emitting directives as Fortran in the mdBook

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ee66c1e908832f82029de9a847d705