### PR TITLE
Round-trip OpenMP_VV pragmas through clang-format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,10 +18,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "autocfg"
@@ -87,6 +131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4512b90fa68d3a9932cea5184017c5d200f5921df706d45e853537dea51508f"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -95,8 +140,22 @@ version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0025e98baa12e766c67ba13ff4695a887a1eba19569aad00a472546795bd6730"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -104,6 +163,12 @@ name = "clap_lex"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "criterion"
@@ -267,6 +332,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +353,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -358,6 +435,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "oorandom"
@@ -508,12 +591,14 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 name = "roup"
 version = "0.4.0"
 dependencies = [
+ "clap",
  "criterion",
  "nom",
  "once_cell",
  "parking_lot",
  "serial_test",
  "syn",
+ "walkdir",
 ]
 
 [[package]]
@@ -639,6 +724,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +755,12 @@ name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "walkdir"
@@ -765,7 +862,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -783,14 +889,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -800,10 +923,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -812,10 +947,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -824,10 +971,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -836,10 +995,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ license = "BSD-3-Clause"
 # nom = parser combinator library for building parsers
 # Version 8.0.0 uses semantic versioning
 nom = "8.0.0"
+clap = { version = "4.5", features = ["derive"] }
+walkdir = "2.5"
 
 # FFI layer dependencies (100% safe Rust)
 once_cell = "1"     # Lazy static initialization
@@ -48,6 +50,10 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 [[bin]]
 name = "tester"
 path = "utils/tester.rs"
+
+[[bin]]
+name = "openmp_vv"
+path = "src/bin/openmp_vv.rs"
 
 # Benchmark configuration
 [[bench]]

--- a/TESTING.md
+++ b/TESTING.md
@@ -365,6 +365,40 @@ Failed versions:
 
 This clearly shows which version failed and why.
 
+## OpenMP_VV Validation Harness
+
+ROUP can reuse the [OpenMP Validation & Verification](https://github.com/OpenMP-Validation-and-Verification/OpenMP_VV) test
+suite to sanity-check directive coverage across real-world programs.
+
+### Running the Harness
+
+```bash
+# Round-trip OpenMP pragmas under OpenMP_VV/tests and summarize the results
+cargo run --bin openmp_vv
+
+# Reuse an existing checkout (skips cloning into target/openmp_vv)
+cargo run --bin openmp_vv -- --repo-path /path/to/OpenMP_VV --skip-clone
+
+# Show every failure instead of truncating after 20 entries
+cargo run --bin openmp_vv -- --max-failures 0
+
+# Forward extra clang flags (repeatable) and override the clang-format binary
+cargo run --bin openmp_vv -- --clang-arg -std=c99 --clang-format /path/to/clang-format-18
+```
+
+The first run clones `OpenMP_VV` into `target/openmp_vv`. Subsequent executions reuse that clone unless you specify a
+custom `--repo-path`. The harness walks every C/C++ source file under `tests/`, preprocesses it with `clang -E` to collapse
+continuations and macro expansions, normalizes each discovered `#pragma omp` with `clang-format`, and then asks ROUP to
+parse + unparse the directive. The round-tripped string is formatted again with `clang-format` and compared against the
+original formatted directive. The summary reports:
+
+- Total directives checked, successes, and mismatches
+- Language-level breakdown (C vs C++)
+- Representative failures with side-by-side original/rewritten pragmas
+
+Use `--max-failures` to control how many individual diagnostics are shown, `--include` to forward additional include
+directories to clang, and `--skip-clone` to enforce offline execution when the repository is already present locally.
+
 ## FAQ
 
 **Q: Why MSRV + stable instead of testing many versions?**

--- a/src/bin/openmp_vv.rs
+++ b/src/bin/openmp_vv.rs
@@ -1,0 +1,546 @@
+use std::collections::HashMap;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use clap::{ArgAction, Parser};
+use roup::lexer::Language;
+use roup::parser::Parser as OmpParser;
+use walkdir::WalkDir;
+
+type DynError = Box<dyn std::error::Error>;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "roup-openmp-vv",
+    about = "Validate that ROUP round-trips OpenMP pragmas from OpenMP_VV"
+)]
+struct Args {
+    /// Location of the OpenMP_VV repository on disk. Defaults to target/openmp_vv.
+    #[arg(long)]
+    repo_path: Option<PathBuf>,
+
+    /// Git URL used when cloning the OpenMP_VV repository.
+    #[arg(
+        long,
+        default_value = "https://github.com/OpenMP-Validation-and-Verification/OpenMP_VV"
+    )]
+    repo_url: String,
+
+    /// Relative path (within the repository) that contains the tests directory.
+    #[arg(long, default_value = "tests")]
+    tests_dir: PathBuf,
+
+    /// Skip cloning when the repository does not exist yet.
+    #[arg(long)]
+    skip_clone: bool,
+
+    /// Path to the clang executable used for preprocessing.
+    #[arg(long, default_value = "clang")]
+    clang: String,
+
+    /// Additional argument passed to clang (can be repeated).
+    #[arg(long = "clang-arg", action = ArgAction::Append)]
+    clang_arg: Vec<String>,
+
+    /// Path to the clang-format executable used for canonicalizing pragmas.
+    #[arg(long, default_value = "clang-format")]
+    clang_format: String,
+
+    /// Additional argument passed to clang-format (can be repeated).
+    #[arg(long = "clang-format-arg", action = ArgAction::Append)]
+    clang_format_arg: Vec<String>,
+
+    /// Extra include directories forwarded to clang during preprocessing.
+    #[arg(long = "include", action = ArgAction::Append)]
+    include_dirs: Vec<PathBuf>,
+
+    /// Maximum number of failures to print in the report. Set to 0 for unlimited.
+    #[arg(long, default_value_t = 20)]
+    max_failures: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum SourceLanguage {
+    C,
+    Cxx,
+}
+
+impl SourceLanguage {
+    fn label(self) -> &'static str {
+        match self {
+            SourceLanguage::C => "C",
+            SourceLanguage::Cxx => "C++",
+        }
+    }
+
+    fn assume_filename(self) -> &'static str {
+        match self {
+            SourceLanguage::C => "file.c",
+            SourceLanguage::Cxx => "file.cpp",
+        }
+    }
+
+    fn clang_language(self) -> &'static str {
+        match self {
+            SourceLanguage::C => "c",
+            SourceLanguage::Cxx => "c++",
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+struct LanguageStats {
+    directives: usize,
+    successes: usize,
+}
+
+#[derive(Debug, Clone)]
+struct DirectiveRecord {
+    path: PathBuf,
+    line: usize,
+    language: SourceLanguage,
+    pragma: String,
+}
+
+#[derive(Debug)]
+struct FailureRecord {
+    path: PathBuf,
+    line: usize,
+    language: SourceLanguage,
+    original: String,
+    rewritten: Option<String>,
+    error: String,
+}
+
+struct ParserCache {
+    c: OmpParser,
+}
+
+impl ParserCache {
+    fn new() -> Self {
+        Self {
+            c: OmpParser::default().with_language(Language::C),
+        }
+    }
+
+    fn parser(&self, language: SourceLanguage) -> &OmpParser {
+        match language {
+            SourceLanguage::C | SourceLanguage::Cxx => &self.c,
+        }
+    }
+}
+
+fn main() -> Result<(), DynError> {
+    let args = Args::parse();
+
+    let repo_path = args
+        .repo_path
+        .clone()
+        .unwrap_or_else(|| PathBuf::from("target").join("openmp_vv"));
+
+    ensure_repo(&repo_path, &args.repo_url, args.skip_clone)?;
+
+    let tests_root = repo_path.join(&args.tests_dir);
+    if !tests_root.exists() {
+        return Err(format!("tests directory {} does not exist", tests_root.display()).into());
+    }
+
+    let mut stats: HashMap<SourceLanguage, LanguageStats> = HashMap::new();
+    let mut failures = Vec::new();
+
+    let parser_cache = ParserCache::new();
+
+    for entry in WalkDir::new(&tests_root) {
+        let entry = entry?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        let Some(language) = detect_language(entry.path()) else {
+            continue;
+        };
+
+        let canonical_path = entry.path().canonicalize()?;
+        let preprocessed = match preprocess_file(&args, &repo_path, &canonical_path, language) {
+            Ok(output) => output,
+            Err(err) => {
+                failures.push(FailureRecord {
+                    path: canonical_path.clone(),
+                    line: 0,
+                    language,
+                    original: String::new(),
+                    rewritten: None,
+                    error: format!("failed to preprocess with clang: {err}"),
+                });
+                continue;
+            }
+        };
+
+        let directives = extract_directives(&preprocessed, &canonical_path, language);
+        if directives.is_empty() {
+            continue;
+        }
+
+        let entry_stats = stats.entry(language).or_default();
+        entry_stats.directives += directives.len();
+
+        for directive in directives {
+            match validate_directive(&args, &parser_cache, &directive) {
+                Ok(_) => entry_stats.successes += 1,
+                Err(failure) => failures.push(failure),
+            }
+        }
+    }
+
+    print_summary(&stats, &failures, args.max_failures);
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        std::process::exit(1);
+    }
+}
+
+fn ensure_repo(repo_path: &Path, repo_url: &str, skip_clone: bool) -> Result<(), DynError> {
+    if repo_path.exists() {
+        return Ok(());
+    }
+
+    if skip_clone {
+        return Err(format!(
+            "repository {} does not exist and --skip-clone was provided",
+            repo_path.display()
+        )
+        .into());
+    }
+
+    if let Some(parent) = repo_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let status = Command::new("git")
+        .arg("clone")
+        .arg(repo_url)
+        .arg(repo_path)
+        .status()?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err("failed to clone OpenMP_VV".into())
+    }
+}
+
+fn detect_language(path: &Path) -> Option<SourceLanguage> {
+    let ext = path.extension()?.to_str()?.to_ascii_lowercase();
+    match ext.as_str() {
+        "c" | "i" => Some(SourceLanguage::C),
+        "cc" | "cpp" | "cxx" | "c++" => Some(SourceLanguage::Cxx),
+        _ => None,
+    }
+}
+
+fn preprocess_file(
+    args: &Args,
+    repo_root: &Path,
+    path: &Path,
+    language: SourceLanguage,
+) -> Result<String, DynError> {
+    let mut command = Command::new(&args.clang);
+    command.current_dir(repo_root);
+    command.arg("-E");
+    command.arg("-fopenmp");
+    command.arg("-CC");
+    command.arg("-x");
+    command.arg(language.clang_language());
+
+    for dir in &args.include_dirs {
+        command.arg("-I");
+        command.arg(dir);
+    }
+    if let Some(parent) = path.parent() {
+        command.arg("-I");
+        command.arg(parent);
+    }
+
+    for extra in &args.clang_arg {
+        command.arg(extra);
+    }
+
+    command.arg(path);
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+
+    let output = command.output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("clang failed: {stderr}").into());
+    }
+
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+fn extract_directives(
+    preprocessed: &str,
+    original_path: &Path,
+    language: SourceLanguage,
+) -> Vec<DirectiveRecord> {
+    let mut current_path = original_path.to_path_buf();
+    let mut current_line: usize = 0;
+    let mut directives = Vec::new();
+
+    for raw_line in preprocessed.lines() {
+        let line = raw_line.trim_end();
+
+        if let Some(rest) = line.strip_prefix('#') {
+            if let Some((line_no, path)) = parse_line_marker(rest, original_path.parent()) {
+                current_line = line_no.saturating_sub(1);
+                if let Some(path) = path {
+                    current_path = path;
+                }
+            }
+            continue;
+        }
+
+        current_line = current_line.saturating_add(1);
+
+        let needle = match language {
+            SourceLanguage::C | SourceLanguage::Cxx => "#pragma omp",
+        };
+
+        if let Some(idx) = line.find(needle) {
+            let pragma = line[idx..].trim().to_string();
+            if current_path == original_path {
+                directives.push(DirectiveRecord {
+                    path: current_path.clone(),
+                    line: current_line,
+                    language,
+                    pragma,
+                });
+            }
+        }
+    }
+
+    directives
+}
+
+fn parse_line_marker(rest: &str, base_dir: Option<&Path>) -> Option<(usize, Option<PathBuf>)> {
+    let trimmed = rest.trim_start();
+    let trimmed = if let Some(stripped) = trimmed.strip_prefix("line") {
+        stripped.trim_start()
+    } else {
+        trimmed
+    };
+
+    let mut parts = trimmed.split_whitespace();
+    let line_number = parts.next()?.parse().ok()?;
+    let file = parts
+        .next()
+        .map(|token| token.trim_matches('"'))
+        .and_then(|token| resolve_marker_path(token, base_dir));
+    Some((line_number, file))
+}
+
+fn resolve_marker_path(token: &str, base_dir: Option<&Path>) -> Option<PathBuf> {
+    if token.starts_with('<') {
+        return None;
+    }
+
+    let raw_path = PathBuf::from(token);
+    let resolved = if raw_path.is_relative() {
+        base_dir.map(|dir| dir.join(&raw_path)).unwrap_or(raw_path)
+    } else {
+        raw_path
+    };
+
+    match resolved.canonicalize() {
+        Ok(canonical) => Some(canonical),
+        Err(_) => Some(resolved),
+    }
+}
+
+fn validate_directive(
+    args: &Args,
+    parser_cache: &ParserCache,
+    directive: &DirectiveRecord,
+) -> Result<(), FailureRecord> {
+    let formatted_input = match clang_format(&args.clang_format, &args.clang_format_arg, directive)
+    {
+        Ok(output) => output,
+        Err(err) => {
+            return Err(FailureRecord {
+                path: directive.path.clone(),
+                line: directive.line,
+                language: directive.language,
+                original: directive.pragma.clone(),
+                rewritten: None,
+                error: format!("clang-format failed: {err}"),
+            })
+        }
+    };
+
+    let parser = parser_cache.parser(directive.language);
+    let trimmed_input = formatted_input.trim().to_string();
+    match parser.parse(&trimmed_input) {
+        Ok((rest, parsed)) => {
+            if !rest.trim().is_empty() {
+                return Err(FailureRecord {
+                    path: directive.path.clone(),
+                    line: directive.line,
+                    language: directive.language,
+                    original: formatted_input.clone(),
+                    rewritten: None,
+                    error: format!("unexpected trailing input: {rest:?}"),
+                });
+            }
+
+            let rewritten = parsed.to_pragma_string();
+            let formatted_rewritten = match clang_format(
+                &args.clang_format,
+                &args.clang_format_arg,
+                &DirectiveRecord {
+                    pragma: rewritten,
+                    ..directive.clone()
+                },
+            ) {
+                Ok(text) => text,
+                Err(err) => {
+                    return Err(FailureRecord {
+                        path: directive.path.clone(),
+                        line: directive.line,
+                        language: directive.language,
+                        original: formatted_input.clone(),
+                        rewritten: None,
+                        error: format!("clang-format failed for rewritten pragma: {err}"),
+                    });
+                }
+            };
+
+            if normalize(&formatted_input) == normalize(&formatted_rewritten) {
+                Ok(())
+            } else {
+                Err(FailureRecord {
+                    path: directive.path.clone(),
+                    line: directive.line,
+                    language: directive.language,
+                    original: formatted_input,
+                    rewritten: Some(formatted_rewritten),
+                    error: "formatted pragma mismatch".into(),
+                })
+            }
+        }
+        Err(err) => Err(FailureRecord {
+            path: directive.path.clone(),
+            line: directive.line,
+            language: directive.language,
+            original: formatted_input.clone(),
+            rewritten: None,
+            error: format!("parser error: {err}"),
+        }),
+    }
+}
+
+fn clang_format(
+    clang_format: &str,
+    extra_args: &[String],
+    directive: &DirectiveRecord,
+) -> Result<String, DynError> {
+    let mut command = Command::new(clang_format);
+    command.arg("--assume-filename");
+    command.arg(directive.language.assume_filename());
+    for extra in extra_args {
+        command.arg(extra);
+    }
+    command.stdin(Stdio::piped());
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+
+    let mut child = command.spawn()?;
+    {
+        let stdin = child
+            .stdin
+            .as_mut()
+            .ok_or("failed to open clang-format stdin")?;
+        let mut payload = directive.pragma.clone();
+        if !payload.ends_with('\n') {
+            payload.push('\n');
+        }
+        stdin.write_all(payload.as_bytes())?;
+    }
+
+    let output = child.wait_with_output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("clang-format failed: {stderr}").into());
+    }
+
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+fn normalize(text: &str) -> String {
+    text.replace('\r', "").trim_end().to_string()
+}
+
+fn print_summary(
+    stats: &HashMap<SourceLanguage, LanguageStats>,
+    failures: &[FailureRecord],
+    max: usize,
+) {
+    println!("Round-trip validation summary:\n");
+
+    let mut totals = LanguageStats::default();
+    for language in [SourceLanguage::C, SourceLanguage::Cxx] {
+        if let Some(stat) = stats.get(&language) {
+            println!(
+                "  {:<8} - {} / {} directives matched",
+                language.label(),
+                stat.successes,
+                stat.directives
+            );
+            totals.directives += stat.directives;
+            totals.successes += stat.successes;
+        }
+    }
+
+    println!();
+    println!(
+        "  Overall  - {} / {} directives matched",
+        totals.successes, totals.directives
+    );
+
+    if failures.is_empty() {
+        println!("\nAll directives matched after round-tripping.");
+        return;
+    }
+
+    println!("\nFailures (showing up to {max}):");
+    let to_show = if max == 0 {
+        failures.len()
+    } else {
+        failures.len().min(max)
+    };
+    for failure in failures.iter().take(to_show) {
+        println!(
+            "\n{}:{} ({}) - {}",
+            failure.path.display(),
+            failure.line,
+            failure.language.label(),
+            failure.error
+        );
+        if !failure.original.is_empty() {
+            println!("  original : {}", failure.original.trim_end());
+        }
+        if let Some(ref rewritten) = failure.rewritten {
+            println!("  rewritten: {}", rewritten.trim_end());
+        }
+    }
+
+    if failures.len() > to_show {
+        println!(
+            "\n... {} additional failures omitted (use --max-failures 0 to show all)",
+            failures.len() - to_show
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- rewrite the OpenMP_VV harness to preprocess with clang, normalize pragmas with clang-format, and round-trip them through ROUP
- compare clang-formatted input/output pragmas to flag mismatches and report aggregated C/C++ statistics
- update TESTING.md with the streamlined workflow and new CLI flags for clang/clang-format and include directories

## Testing
- cargo check --bin openmp_vv

------
https://chatgpt.com/codex/tasks/task_e_68f28be3bba0832fb7448d4296ab8ceb