### PR TITLE
Simplify OpenMP_VV harness with clang round-trip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,10 +18,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "autocfg"
@@ -87,6 +131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4512b90fa68d3a9932cea5184017c5d200f5921df706d45e853537dea51508f"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -95,8 +140,22 @@ version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0025e98baa12e766c67ba13ff4695a887a1eba19569aad00a472546795bd6730"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -104,6 +163,12 @@ name = "clap_lex"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "criterion"
@@ -267,6 +332,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +353,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -358,6 +435,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "oorandom"
@@ -508,12 +591,14 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 name = "roup"
 version = "0.4.0"
 dependencies = [
+ "clap",
  "criterion",
  "nom",
  "once_cell",
  "parking_lot",
  "serial_test",
  "syn",
+ "walkdir",
 ]
 
 [[package]]
@@ -639,6 +724,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +755,12 @@ name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "walkdir"
@@ -765,7 +862,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -783,14 +889,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -800,10 +923,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -812,10 +947,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -824,10 +971,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -836,10 +995,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ license = "BSD-3-Clause"
 # nom = parser combinator library for building parsers
 # Version 8.0.0 uses semantic versioning
 nom = "8.0.0"
+clap = { version = "4.5", features = ["derive"] }
+walkdir = "2.5"
 
 # FFI layer dependencies (100% safe Rust)
 once_cell = "1"     # Lazy static initialization
@@ -48,6 +50,10 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 [[bin]]
 name = "tester"
 path = "utils/tester.rs"
+
+[[bin]]
+name = "openmp_vv"
+path = "src/bin/openmp_vv.rs"
 
 # Benchmark configuration
 [[bench]]

--- a/TESTING.md
+++ b/TESTING.md
@@ -365,6 +365,34 @@ Failed versions:
 
 This clearly shows which version failed and why.
 
+## OpenMP_VV Round-Trip Harness
+
+ROUP can reuse the [OpenMP Validation & Verification](https://github.com/OpenMP-Validation-and-Verification/OpenMP_VV) test
+suite to smoke-test the parser by round-tripping every pragma.
+
+### Running the Harness
+
+```bash
+# Clone OpenMP_VV (if needed), preprocess, and verify every pragma round-trip
+cargo run --bin openmp_vv
+
+# Reuse an existing checkout (skips cloning into target/openmp_vv)
+cargo run --bin openmp_vv -- --repo-path /path/to/OpenMP_VV --skip-clone
+
+# Use custom toolchain locations
+cargo run --bin openmp_vv -- --clang /opt/clang/bin/clang --clang-format /opt/clang/bin/clang-format
+```
+
+The first run clones `OpenMP_VV` into `target/openmp_vv`. Subsequent executions reuse that clone unless you supply a
+different `--repo-path`. The harness walks every C/C++ source under `tests/`, expands macros with `clang -E -P -CC` (adding
+`-fopenmp` and the file's directory to the include path), formats the resulting `#pragma omp` lines with `clang-format`, and
+feeds each directive through ROUP. The directives produced by `Directive::to_pragma_string()` are formatted a second time
+with `clang-format`; if the normalized input and output differ, the harness reports a mismatch.
+
+The summary shows how many files contained OpenMP pragmas, how many round-tripped successfully, and the overall success rate.
+Detailed sections list round-trip mismatches, parse failures, or tool execution issues (e.g., missing `clang-format`).
+Currently the harness only processes C/C++ sources; Fortran coverage will be added separately.
+
 ## FAQ
 
 **Q: Why MSRV + stable instead of testing many versions?**

--- a/src/bin/openmp_vv.rs
+++ b/src/bin/openmp_vv.rs
@@ -1,0 +1,419 @@
+use std::error::Error;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use clap::Parser;
+use roup::lexer::Language;
+use roup::parser::Parser as OmpParser;
+use walkdir::WalkDir;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "roup-openmp-vv",
+    about = "Round-trip OpenMP pragmas from OpenMP_VV using ROUP"
+)]
+struct Args {
+    /// Location of the OpenMP_VV repository on disk. Defaults to target/openmp_vv.
+    #[arg(long)]
+    repo_path: Option<PathBuf>,
+
+    /// Git URL used when cloning the OpenMP_VV repository.
+    #[arg(
+        long,
+        default_value = "https://github.com/OpenMP-Validation-and-Verification/OpenMP_VV"
+    )]
+    repo_url: String,
+
+    /// Relative path (within the repository) that contains the tests directory.
+    #[arg(long, default_value = "tests")]
+    tests_dir: PathBuf,
+
+    /// Skip cloning when the repository does not exist yet.
+    #[arg(long)]
+    skip_clone: bool,
+
+    /// clang executable used for preprocessing OpenMP_VV sources.
+    #[arg(long, default_value = "clang")]
+    clang: String,
+
+    /// clang-format executable used for normalizing pragma strings.
+    #[arg(long, default_value = "clang-format")]
+    clang_format: String,
+}
+
+struct Context<'a> {
+    repo_path: &'a Path,
+    clang: &'a str,
+    clang_format: &'a str,
+}
+
+#[derive(Debug)]
+enum FileResult {
+    NoPragmas,
+    Match {
+        directives: usize,
+    },
+    Mismatch {
+        directives: usize,
+        expected: String,
+        actual: String,
+    },
+    ParseError {
+        line: usize,
+        directive: String,
+        error: String,
+    },
+}
+
+#[derive(Debug)]
+struct MismatchReport {
+    path: PathBuf,
+    directives: usize,
+    expected: String,
+    actual: String,
+}
+
+#[derive(Debug)]
+struct ParseFailure {
+    path: PathBuf,
+    line: usize,
+    directive: String,
+    error: String,
+}
+
+#[derive(Debug)]
+struct ToolFailure {
+    path: PathBuf,
+    message: String,
+}
+
+type DynResult<T> = Result<T, Box<dyn Error>>;
+
+type ToolResult<T> = Result<T, String>;
+
+fn main() -> DynResult<()> {
+    let args = Args::parse();
+    let repo_path = resolve_repo(&args)?;
+    let tests_root = repo_path.join(&args.tests_dir);
+
+    if !tests_root.is_dir() {
+        return Err(format!("{} is not a directory", tests_root.display()).into());
+    }
+
+    let context = Context {
+        repo_path: &repo_path,
+        clang: &args.clang,
+        clang_format: &args.clang_format,
+    };
+
+    let parser = OmpParser::default().with_language(Language::C);
+
+    let mut files: Vec<PathBuf> = WalkDir::new(&tests_root)
+        .into_iter()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_type().is_file())
+        .map(|entry| entry.into_path())
+        .filter(|path| is_c_like_source(path))
+        .collect();
+    files.sort();
+
+    let mut processed_files = 0usize;
+    let mut successful_files = 0usize;
+    let mut total_directives = 0usize;
+
+    let mut mismatches = Vec::new();
+    let mut parse_failures = Vec::new();
+    let mut tool_failures = Vec::new();
+
+    for path in files {
+        match process_file(&path, &context, &parser) {
+            Ok(FileResult::NoPragmas) => {}
+            Ok(FileResult::Match { directives }) => {
+                processed_files += 1;
+                successful_files += 1;
+                total_directives += directives;
+            }
+            Ok(FileResult::Mismatch {
+                directives,
+                expected,
+                actual,
+            }) => {
+                processed_files += 1;
+                total_directives += directives;
+                mismatches.push(MismatchReport {
+                    path: path.clone(),
+                    directives,
+                    expected,
+                    actual,
+                });
+            }
+            Ok(FileResult::ParseError {
+                line,
+                directive,
+                error,
+            }) => {
+                processed_files += 1;
+                parse_failures.push(ParseFailure {
+                    path: path.clone(),
+                    line,
+                    directive,
+                    error,
+                });
+            }
+            Err(message) => {
+                tool_failures.push(ToolFailure {
+                    path: path.clone(),
+                    message,
+                });
+            }
+        }
+    }
+
+    println!("Round-trip validation summary:");
+    println!("  Files with OpenMP pragmas: {}", processed_files);
+    println!("  Successful round-trips: {}", successful_files);
+    println!("  Total directives checked: {}", total_directives);
+
+    if processed_files > 0 {
+        let rate = (successful_files as f64 / processed_files as f64) * 100.0;
+        println!("  Success rate: {:.1}%", rate);
+    }
+
+    if !mismatches.is_empty() {
+        println!();
+        println!("Round-trip mismatches ({}):", mismatches.len());
+        for report in &mismatches {
+            println!(
+                "- {} ({} directives)",
+                report.path.display(),
+                report.directives
+            );
+            println!("    Expected:");
+            println!("{}", indent_block(&report.expected));
+            println!("    Actual:");
+            println!("{}", indent_block(&report.actual));
+        }
+    }
+
+    if !parse_failures.is_empty() {
+        println!();
+        println!("Parse failures ({}):", parse_failures.len());
+        for failure in &parse_failures {
+            println!("- {}:{}", failure.path.display(), failure.line);
+            println!("    Directive: {}", failure.directive);
+            println!("    Error: {}", failure.error);
+        }
+    }
+
+    if !tool_failures.is_empty() {
+        println!();
+        println!("Tool execution failures ({}):", tool_failures.len());
+        for failure in &tool_failures {
+            println!("- {}", failure.path.display());
+            println!("    {}", failure.message);
+        }
+    }
+
+    if mismatches.is_empty() && parse_failures.is_empty() && tool_failures.is_empty() {
+        Ok(())
+    } else {
+        Err("OpenMP_VV round-trip validation failed".into())
+    }
+}
+
+fn resolve_repo(args: &Args) -> DynResult<PathBuf> {
+    let repo_path = args
+        .repo_path
+        .clone()
+        .unwrap_or_else(|| PathBuf::from("target").join("openmp_vv"));
+
+    if repo_path.exists() {
+        if !repo_path.is_dir() {
+            return Err(format!("{} exists but is not a directory", repo_path.display()).into());
+        }
+        return Ok(repo_path);
+    }
+
+    if args.skip_clone {
+        return Err(format!(
+            "{} does not exist; run without --skip-clone or pass --repo-path",
+            repo_path.display()
+        )
+        .into());
+    }
+
+    if let Some(parent) = repo_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let status = Command::new("git")
+        .arg("clone")
+        .arg("--depth")
+        .arg("1")
+        .arg(&args.repo_url)
+        .arg(&repo_path)
+        .status()?;
+
+    if !status.success() {
+        return Err("failed to clone OpenMP_VV repository".into());
+    }
+
+    Ok(repo_path)
+}
+
+fn process_file(path: &Path, ctx: &Context<'_>, parser: &OmpParser) -> ToolResult<FileResult> {
+    let preprocessed = clang_preprocess(path, ctx)?;
+    let directives: Vec<String> = preprocessed
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.starts_with("#pragma omp") {
+                Some(trimmed.to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if directives.is_empty() {
+        return Ok(FileResult::NoPragmas);
+    }
+
+    // Preserve deterministic order by running clang-format after preprocessing.
+    let canonical_input = clang_format(&directives.join("\n"), ctx)?
+        .trim()
+        .to_string();
+
+    if canonical_input.is_empty() {
+        return Ok(FileResult::NoPragmas);
+    }
+
+    let mut round_tripped = Vec::with_capacity(directives.len());
+
+    for (idx, directive) in directives.iter().enumerate() {
+        let parse_result = parser.parse(directive.as_str());
+        let (rest, parsed) = match parse_result {
+            Ok(value) => value,
+            Err(err) => {
+                return Ok(FileResult::ParseError {
+                    line: idx + 1,
+                    directive: directive.clone(),
+                    error: format!("{err:?}"),
+                });
+            }
+        };
+
+        if !rest.trim().is_empty() {
+            return Ok(FileResult::ParseError {
+                line: idx + 1,
+                directive: directive.clone(),
+                error: format!("unexpected trailing input: {rest}"),
+            });
+        }
+
+        round_tripped.push(parsed.to_pragma_string());
+    }
+
+    let canonical_output = clang_format(&round_tripped.join("\n"), ctx)?
+        .trim()
+        .to_string();
+
+    if canonical_input == canonical_output {
+        Ok(FileResult::Match {
+            directives: round_tripped.len(),
+        })
+    } else {
+        Ok(FileResult::Mismatch {
+            directives: round_tripped.len(),
+            expected: canonical_input,
+            actual: canonical_output,
+        })
+    }
+}
+
+fn clang_preprocess(path: &Path, ctx: &Context<'_>) -> ToolResult<String> {
+    let mut command = Command::new(ctx.clang);
+    command
+        .current_dir(ctx.repo_path)
+        .arg("-E")
+        .arg("-P")
+        .arg("-CC")
+        .arg("-fopenmp");
+
+    if let Some(parent) = path.parent() {
+        command.arg("-I").arg(parent);
+    }
+
+    command.arg(path);
+
+    let output = command
+        .output()
+        .map_err(|err| format!("failed to run clang: {err}"))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "clang returned {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    String::from_utf8(output.stdout)
+        .map_err(|err| format!("clang output was not valid UTF-8: {err}"))
+}
+
+fn clang_format(input: &str, ctx: &Context<'_>) -> ToolResult<String> {
+    let mut child = Command::new(ctx.clang_format)
+        .arg("-style")
+        .arg("LLVM")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|err| format!("failed to run clang-format: {err}"))?;
+
+    if let Some(stdin) = child.stdin.as_mut() {
+        stdin
+            .write_all(input.as_bytes())
+            .map_err(|err| format!("failed to write to clang-format stdin: {err}"))?;
+    }
+
+    let output = child
+        .wait_with_output()
+        .map_err(|err| format!("failed to read clang-format output: {err}"))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "clang-format returned {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    String::from_utf8(output.stdout)
+        .map_err(|err| format!("clang-format output was not valid UTF-8: {err}"))
+}
+
+fn is_c_like_source(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| {
+            ext.eq_ignore_ascii_case("c")
+                || ext.eq_ignore_ascii_case("cc")
+                || ext.eq_ignore_ascii_case("cp")
+                || ext.eq_ignore_ascii_case("cxx")
+                || ext.eq_ignore_ascii_case("cpp")
+                || ext.eq_ignore_ascii_case("c++")
+                || ext.eq_ignore_ascii_case("i")
+        })
+        .unwrap_or(false)
+}
+
+fn indent_block(text: &str) -> String {
+    text.lines()
+        .map(|line| format!("      {line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}


### PR DESCRIPTION
## Summary
- replace the OpenMP_VV harness with a clang/clang-format round-trip that compares ROUP output to the canonical pragma string
- report mismatches, parse failures, and tool invocation issues with a simple success summary
- update TESTING.md to document the new workflow and options

## Testing
- cargo check --bin openmp_vv

------
https://chatgpt.com/codex/tasks/task_e_68f28be3bba0832fb7448d4296ab8ceb