### PR TITLE
Add OpenACCV-V validation suite

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -468,6 +468,76 @@ The validation uses two simple components:
 
 This approach is simpler and more maintainable than complex Rust-only solutions.
 
+## OpenACCV-V Round-Trip Validation
+
+ROUP can now validate OpenACC support against the [OpenACCV-V](https://github.com/OpenACCUserGroup/OpenACCV-V) test suite. Every `#pragma acc` or `!$acc` directive is parsed and re-emitted to ensure round-trip stability across both C/C++ and Fortran sources.
+
+### How It Works
+
+1. **Clone OpenACCV-V** (first run only, into `target/openacc_vv`).
+2. **Scan every source in `Tests/`** for OpenACC directives (C/C++ and Fortran).
+3. **Round-trip each directive** through `roup_roundtrip` configured for OpenACC, preserving dialect-specific language settings.
+4. **Normalize** both original and round-tripped directives by converting them to canonical `#pragma acc ...` strings and collapsing whitespace.
+5. **Report statistics**: totals, pass/fail counts, and overall success rate.
+
+### Running the Test
+
+```bash
+# Run OpenACCV-V validation (auto-clones repository if needed)
+./test_openacc_vv.sh
+
+# Or as part of the full test suite
+./test.sh  # Includes OpenACCV-V as section 20
+```
+
+### Using Existing Repository or Custom Tools
+
+```bash
+# Point to an existing clone
+OPENACC_VV_PATH=/path/to/OpenACCV-V ./test_openacc_vv.sh
+
+# Override the Python interpreter
+PYTHON=python ./test_openacc_vv.sh
+```
+
+### Example Output
+
+```
+=========================================
+  OpenACCV-V Round-Trip Validation
+=========================================
+
+Checking for required tools...
+✓ All required tools found
+
+Using existing OpenACCV-V at target/openacc_vv
+
+Building roup_roundtrip binary...
+✓ Binary built
+
+Files processed:        1338
+Files with directives:  1305
+Total directives:       6307
+  C/C++ directives:     5773
+  Fortran directives:   534
+
+Passed:                 6307
+Failed:                 0
+  Parse errors:         0
+  Mismatches:           0
+
+Success rate:           100.0%
+```
+
+### Requirements
+
+- **python3** – Runs the extraction/analysis helper script
+- **cargo** – Builds `roup_roundtrip`
+- **git** – Clones OpenACCV-V when needed
+
+Whitespace normalization is implemented directly in the script, so no external formatting tools are required.
+
+
 ## FAQ
 
 **Q: Why MSRV + stable instead of testing many versions?**

--- a/scripts/openacc_vv_runner.py
+++ b/scripts/openacc_vv_runner.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""OpenACCV-V validation runner.
+
+This script scans the OpenACCV-V test suite, extracts every OpenACC directive,
+round-trips it through the `roup_roundtrip` binary, and reports pass/fail
+statistics.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+VALID_EXTENSIONS = {
+    ".c",
+    ".cc",
+    ".cpp",
+    ".cxx",
+    ".h",
+    ".hh",
+    ".hpp",
+    ".hxx",
+    ".f",
+    ".f90",
+    ".f95",
+    ".f03",
+    ".f08",
+    ".F",
+    ".F90",
+    ".F95",
+    ".F03",
+    ".F08",
+}
+
+
+@dataclass
+class Directive:
+    path: Path
+    start_line: int
+    lines: List[str]
+    language: str  # "c" or "fortran"
+    prefix: str
+
+    def parser_input(self) -> str:
+        cleaned: List[str] = []
+        for idx, raw_line in enumerate(self.lines):
+            if self.language == "c":
+                line = _strip_c_comment(raw_line)
+            else:
+                line = _strip_fortran_comment(raw_line, idx == 0, len(self.prefix))
+            cleaned.append(line.rstrip())
+        result = "\n".join(part for part in cleaned if part.strip())
+        return _normalize_directive_text(result)
+
+    def canonicalize(self, text: str) -> str:
+        c_style = self._to_c_style(text)
+        if not c_style:
+            return ""
+        return " ".join(c_style.split())
+
+    def _to_c_style(self, text: str) -> str:
+        parts: List[str] = []
+        lines = [segment for segment in text.strip().splitlines() if segment.strip()]
+        if self.language == "c":
+            for line in lines:
+                stripped = line.strip()
+                if stripped.endswith("\\"):
+                    stripped = stripped[:-1].rstrip()
+                parts.append(stripped)
+            joined = " ".join(parts)
+            return _normalize_directive_text(joined)
+
+        # Fortran: strip sentinel/continuation markers, then convert to #pragma form
+        for idx, line in enumerate(lines):
+            stripped = line.strip()
+            if idx == 0:
+                body = stripped[len(self.prefix) :].lstrip()
+            else:
+                body = stripped.lstrip()
+            if body.startswith("&"):
+                body = body[1:].lstrip()
+            if body.endswith("&"):
+                body = body[:-1].rstrip()
+            if body:
+                parts.append(body)
+        joined = " ".join(parts).strip()
+        if joined:
+            return _normalize_directive_text(f"#pragma acc {joined}")
+        return "#pragma acc"
+
+
+def _strip_c_comment(line: str) -> str:
+    trimmed = line.rstrip()
+    if "//" in trimmed:
+        idx = trimmed.find("//")
+        return trimmed[:idx].rstrip()
+    return trimmed
+
+
+def _strip_fortran_comment(line: str, is_first: bool, prefix_len: int) -> str:
+    trimmed = line.rstrip()
+    start = prefix_len if is_first else 0
+    for idx, ch in enumerate(trimmed):
+        if idx < start:
+            continue
+        if ch == "!":
+            return trimmed[:idx].rstrip()
+    return trimmed
+
+
+def _detect_directives(path: Path) -> Iterable[Directive]:
+    try:
+        content = path.read_text()
+    except UnicodeDecodeError:
+        return []
+
+    directives: List[Directive] = []
+    lines = content.splitlines()
+    i = 0
+    while i < len(lines):
+        original_line = lines[i]
+        stripped = original_line.lstrip()
+        lower = stripped.lower()
+        directive_info: Optional[tuple[str, str]] = None
+        if lower.startswith("#pragma acc"):
+            # Preserve prefix with original casing/spacing
+            prefix_end = len(stripped.split(None, 2)[0])
+            prefix = stripped[:prefix_end]
+            directive_info = ("c", prefix)
+        elif lower.startswith("!$acc") or lower.startswith("c$acc") or lower.startswith("*$acc"):
+            prefix = stripped[:5]
+            directive_info = ("fortran", prefix)
+
+        if directive_info is None:
+            i += 1
+            continue
+
+        language, prefix = directive_info
+        start_line = i + 1
+        collected = [original_line]
+
+        if language == "c":
+            while collected[-1].rstrip().endswith("\\") and i + 1 < len(lines):
+                i += 1
+                collected.append(lines[i])
+        else:
+            while collected[-1].rstrip().endswith("&") and i + 1 < len(lines):
+                i += 1
+                collected.append(lines[i])
+        directives.append(Directive(path, start_line, collected, language, prefix))
+        i += 1
+    return directives
+
+
+def run_roundtrip(directive: Directive, roundtrip_bin: Path) -> subprocess.CompletedProcess[str]:
+    parser_input = directive.parser_input()
+    return subprocess.run(
+        [roundtrip_bin],
+        input=parser_input,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _normalize_directive_text(text: str) -> str:
+    text = text.replace("\n", " ")
+    text = text.replace("),", ") ")
+    text = re.sub(r"(?<=\w)\s+\(", "(", text)
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run OpenACCV-V validation")
+    parser.add_argument("--tests-dir", required=True, help="Path to OpenACCV-V Tests directory")
+    parser.add_argument("--roundtrip-bin", required=True, help="Path to roup_roundtrip binary")
+    parser.add_argument(
+        "--max-failures",
+        type=int,
+        default=10,
+        help="Maximum number of failures to display",
+    )
+    args = parser.parse_args()
+
+    tests_dir = Path(args.tests_dir)
+    if not tests_dir.is_dir():
+        print(f"Error: Tests directory not found: {tests_dir}")
+        return 1
+
+    roundtrip_bin = Path(args.roundtrip_bin)
+    if not roundtrip_bin.exists():
+        print(f"Error: roundtrip binary not found: {roundtrip_bin}")
+        return 1
+
+    all_files = sorted(
+        path
+        for path in tests_dir.rglob("*")
+        if path.is_file() and path.suffix in VALID_EXTENSIONS
+    )
+
+    total_files = len(all_files)
+    files_with_directives = 0
+    total_directives = 0
+    c_directives = 0
+    fortran_directives = 0
+    passed = 0
+    failed = 0
+    parse_errors = 0
+    failures = []
+
+    for file_path in all_files:
+        directives = list(_detect_directives(file_path))
+        if not directives:
+            continue
+        files_with_directives += 1
+        for directive in directives:
+            parser_input = directive.parser_input()
+            if not parser_input:
+                continue
+            total_directives += 1
+            if directive.language == "c":
+                c_directives += 1
+            else:
+                fortran_directives += 1
+
+            result = run_roundtrip(directive, roundtrip_bin)
+            if result.returncode != 0:
+                failed += 1
+                parse_errors += 1
+                failures.append(
+                    {
+                        "path": directive.path,
+                        "line": directive.start_line,
+                        "reason": result.stderr.strip() or "Parse error",
+                        "original": parser_input,
+                        "roundtrip": "",
+                    }
+                )
+                continue
+
+            output = result.stdout.strip()
+            original_norm = directive.canonicalize(parser_input)
+            roundtrip_norm = directive.canonicalize(output)
+            if original_norm == roundtrip_norm:
+                passed += 1
+            else:
+                failed += 1
+                failures.append(
+                    {
+                        "path": directive.path,
+                        "line": directive.start_line,
+                        "reason": "Normalized mismatch",
+                        "original": original_norm,
+                        "roundtrip": roundtrip_norm,
+                    }
+                )
+
+    success_rate = (passed * 100.0 / total_directives) if total_directives else 0.0
+
+    print("=========================================")
+    print("  OpenACCV-V Round-Trip Validation")
+    print("=========================================")
+    print()
+    print(f"Files processed:        {total_files}")
+    print(f"Files with directives:  {files_with_directives}")
+    print(f"Total directives:       {total_directives}")
+    print(f"  C/C++ directives:     {c_directives}")
+    print(f"  Fortran directives:   {fortran_directives}")
+    print()
+    print(f"Passed:                 {passed}")
+    print(f"Failed:                 {failed}")
+    print(f"  Parse errors:         {parse_errors}")
+    print(f"  Mismatches:           {failed - parse_errors}")
+    print()
+    print(f"Success rate:           {success_rate:.1f}%")
+    print()
+
+    if failures:
+        print("=========================================")
+        print(
+            f"  Failure Details (showing first {min(len(failures), args.max_failures)})"
+        )
+        print("=========================================")
+        print()
+        for failure in failures[: args.max_failures]:
+            print(f"{failure['path']}:{failure['line']}")
+            print(f"    Reason:    {failure['reason']}")
+            if failure["original"]:
+                print(f"    Expected:  {failure['original']}")
+            if failure["roundtrip"]:
+                print(f"    Roundtrip: {failure['roundtrip']}")
+            print()
+        if len(failures) > args.max_failures:
+            remaining = len(failures) - args.max_failures
+            print(f"... and {remaining} more failures")
+
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/bin/roup_roundtrip.rs
+++ b/src/bin/roup_roundtrip.rs
@@ -1,5 +1,13 @@
-use roup::parser::openmp;
+use roup::lexer::Language;
+use roup::parser::{openacc, openmp, Dialect};
 use std::io::{self, Read};
+
+#[derive(Debug)]
+struct InputConfig {
+    language: Language,
+    dialect: Dialect,
+    prefix: String,
+}
 
 fn main() {
     let mut input = String::new();
@@ -14,18 +22,179 @@ fn main() {
         std::process::exit(1);
     }
 
-    let parser = openmp::parser();
-    match parser.parse(trimmed) {
+    let config = match detect_config(trimmed) {
+        Ok(config) => config,
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(1);
+        }
+    };
+
+    let sanitized = sanitize_input(trimmed, &config);
+    if sanitized.trim().is_empty() {
+        eprintln!("No directive content after sanitization");
+        std::process::exit(1);
+    }
+
+    let parser = match config.dialect {
+        Dialect::OpenMp => openmp::parser(),
+        Dialect::OpenAcc => openacc::parser(),
+    }
+    .with_language(config.language);
+
+    match parser.parse(&sanitized) {
         Ok((rest, directive)) => {
             if !rest.trim().is_empty() {
                 eprintln!("Unparsed trailing input: '{}'", rest.trim());
                 std::process::exit(1);
             }
-            println!("{}", directive.to_pragma_string());
+            println!("{}", format_output(&directive, &config));
         }
         Err(e) => {
             eprintln!("Parse error: {:?}", e);
             std::process::exit(1);
+        }
+    }
+}
+
+fn detect_config(input: &str) -> Result<InputConfig, String> {
+    let trimmed = input.trim_start();
+
+    if trimmed.len() >= 7 && trimmed[..7].eq_ignore_ascii_case("#pragma") {
+        let after_pragma = &trimmed[7..];
+        let after_pragma_trimmed = after_pragma.trim_start();
+        if after_pragma_trimmed.len() < 3 {
+            return Err("Directive missing dialect keyword after #pragma".into());
+        }
+
+        let dialect_keyword = &after_pragma_trimmed[..3];
+        let whitespace_len = after_pragma.len() - after_pragma_trimmed.len();
+        let prefix_len = 7 + whitespace_len + 3;
+        let prefix = trimmed[..prefix_len].to_string();
+
+        if dialect_keyword.eq_ignore_ascii_case("omp") {
+            return Ok(InputConfig {
+                language: Language::C,
+                dialect: Dialect::OpenMp,
+                prefix,
+            });
+        } else if dialect_keyword.eq_ignore_ascii_case("acc") {
+            return Ok(InputConfig {
+                language: Language::C,
+                dialect: Dialect::OpenAcc,
+                prefix,
+            });
+        }
+
+        return Err(format!(
+            "Unsupported pragma dialect: '{}'. Expected omp or acc.",
+            dialect_keyword
+        ));
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    if lower.starts_with("!$omp") {
+        return Ok(InputConfig {
+            language: Language::FortranFree,
+            dialect: Dialect::OpenMp,
+            prefix: trimmed[..5].to_string(),
+        });
+    }
+    if lower.starts_with("!$acc") {
+        return Ok(InputConfig {
+            language: Language::FortranFree,
+            dialect: Dialect::OpenAcc,
+            prefix: trimmed[..5].to_string(),
+        });
+    }
+    if lower.starts_with("c$omp") || lower.starts_with("*$omp") {
+        return Ok(InputConfig {
+            language: Language::FortranFixed,
+            dialect: Dialect::OpenMp,
+            prefix: trimmed[..5].to_string(),
+        });
+    }
+    if lower.starts_with("c$acc") || lower.starts_with("*$acc") {
+        return Ok(InputConfig {
+            language: Language::FortranFixed,
+            dialect: Dialect::OpenAcc,
+            prefix: trimmed[..5].to_string(),
+        });
+    }
+
+    Err("Unable to detect directive dialect (expected omp/acc pragma or sentinel)".into())
+}
+
+fn sanitize_input(input: &str, config: &InputConfig) -> String {
+    match config.language {
+        Language::C => sanitize_c_like(input),
+        Language::FortranFree | Language::FortranFixed => {
+            sanitize_fortran_like(input, config.prefix.len())
+        }
+    }
+}
+
+fn sanitize_c_like(input: &str) -> String {
+    input
+        .lines()
+        .map(|line| {
+            let trimmed = line.trim_end();
+            if let Some(idx) = trimmed.find("//") {
+                trimmed[..idx].trim_end()
+            } else {
+                trimmed
+            }
+        })
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn sanitize_fortran_like(input: &str, sentinel_len: usize) -> String {
+    input
+        .lines()
+        .enumerate()
+        .map(|(idx, line)| {
+            let trimmed = line.trim_end();
+            let skip = if idx == 0 {
+                sentinel_len.min(trimmed.len())
+            } else {
+                0
+            };
+
+            let mut comment_idx = None;
+            for (pos, ch) in trimmed.char_indices() {
+                if pos < skip {
+                    continue;
+                }
+                if ch == '!' {
+                    comment_idx = Some(pos);
+                    break;
+                }
+            }
+
+            let without_comment = comment_idx
+                .map(|idx| trimmed[..idx].trim_end())
+                .unwrap_or(trimmed);
+            without_comment
+        })
+        .filter(|line| !line.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn format_output(directive: &roup::parser::Directive<'_>, config: &InputConfig) -> String {
+    match config.language {
+        Language::C => directive.to_pragma_string_with_prefix(match config.dialect {
+            Dialect::OpenMp => "#pragma omp",
+            Dialect::OpenAcc => "#pragma acc",
+        }),
+        Language::FortranFree | Language::FortranFixed => {
+            let prefix = match config.dialect {
+                Dialect::OpenMp => "!$omp",
+                Dialect::OpenAcc => "!$acc",
+            };
+            directive.to_pragma_string_with_prefix(prefix)
         }
     }
 }

--- a/test.sh
+++ b/test.sh
@@ -396,7 +396,40 @@ else
 fi
 
 # ===================================================================
-# 20. All Features Test
+# 20. OpenACCV-V Round-Trip Validation (REQUIRED: 100% pass rate)
+# ===================================================================
+SECTION_NUM=$((SECTION_NUM + 1)); echo "=== $SECTION_NUM. OpenACCV-V Round-Trip Validation ==="
+openacc_vv_status="skipped"
+if command -v python3 &>/dev/null; then
+    echo -n "Running OpenACCV-V round-trip test (100% required)... "
+    if ./test_openacc_vv.sh > /tmp/test_openacc_vv.log 2>&1; then
+        failures=$(grep "^Failed:" /tmp/test_openacc_vv.log | grep -o "[0-9]*" || echo "0")
+        if [ "$failures" -eq 0 ]; then
+            echo -e "${GREEN}✓ PASS (100% success rate)${NC}"
+            openacc_vv_status="passed"
+            grep "Success rate:" /tmp/test_openacc_vv.log || true
+        else
+            echo -e "${RED}✗ FAIL - $failures directives failed (100% required)${NC}"
+            grep "Success rate:" /tmp/test_openacc_vv.log || true
+            echo "See /tmp/test_openacc_vv.log for details"
+            tail -50 /tmp/test_openacc_vv.log
+            exit 1
+        fi
+    else
+        echo -e "${RED}✗ FAIL - OpenACCV-V test script failed${NC}"
+        tail -50 /tmp/test_openacc_vv.log
+        exit 1
+    fi
+else
+    echo -e "${RED}✗ FAIL - python3 is REQUIRED for OpenACCV-V validation${NC}"
+    echo "   Install (Debian/Ubuntu): apt-get install python3"
+    echo "   Install (macOS): brew install python"
+    echo "   Install (Fedora/RHEL): dnf install python3"
+    exit 1
+fi
+
+# ===================================================================
+# 21. All Features Test
 # ===================================================================
 SECTION_NUM=$((SECTION_NUM + 1)); echo "=== $SECTION_NUM. All Features Test ==="
 echo -n "Running tests with --all-features... "
@@ -409,7 +442,7 @@ else
 fi
 
 # ===================================================================
-# 21. Benchmark Tests
+# 22. Benchmark Tests
 # ===================================================================
 SECTION_NUM=$((SECTION_NUM + 1)); echo "=== $SECTION_NUM. Benchmark Tests ==="
 if [ ! -d "benches" ]; then
@@ -432,10 +465,17 @@ fi
 # ===================================================================
 echo ""
 echo "========================================"
+total_passed_categories=20
 if [ "$openmp_vv_status" = "passed" ]; then
-    echo -e "  ${GREEN}ALL 21 TEST CATEGORIES PASSED${NC}"
+    total_passed_categories=$((total_passed_categories + 1))
+fi
+if [ "$openacc_vv_status" = "passed" ]; then
+    total_passed_categories=$((total_passed_categories + 1))
+fi
+if [ "$total_passed_categories" -eq 22 ]; then
+    echo -e "  ${GREEN}ALL 22 TEST CATEGORIES PASSED${NC}"
 else
-    echo -e "  ${GREEN}20 TEST CATEGORIES PASSED${NC}"
+    echo -e "  ${GREEN}$total_passed_categories TEST CATEGORIES PASSED${NC}"
 fi
 echo "========================================"
 echo ""
@@ -454,6 +494,11 @@ if [ "$openmp_vv_status" = "passed" ]; then
     echo "  ✓ OpenMP_VV round-trip validation"
 elif [ "$openmp_vv_status" = "skipped" ]; then
     echo "  ⚠ OpenMP_VV round-trip validation (skipped)"
+fi
+if [ "$openacc_vv_status" = "passed" ]; then
+    echo "  ✓ OpenACCV-V round-trip validation"
+elif [ "$openacc_vv_status" = "skipped" ]; then
+    echo "  ⚠ OpenACCV-V round-trip validation (skipped)"
 fi
 echo "  ✓ All features tested"
 echo "  ✓ Benchmarks validated"

--- a/test_openacc_vv.sh
+++ b/test_openacc_vv.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# test_openacc_vv.sh - Round-trip OpenACC directives from OpenACCV-V through ROUP
+#
+# This script validates ROUP by:
+# 1. Cloning the OpenACCV-V test suite (on-demand)
+# 2. Extracting all C/C++/Fortran OpenACC directives
+# 3. Round-tripping each directive through ROUP's parser
+# 4. Normalizing directives and comparing round-tripped output
+# 5. Reporting pass/fail statistics
+#
+# Usage:
+#   ./test_openacc_vv.sh                          # Auto-clone to target/openacc_vv
+#   OPENACC_VV_PATH=/path ./test_openacc_vv.sh    # Use existing clone
+#   PYTHON=python ./test_openacc_vv.sh
+#
+
+set -euo pipefail
+
+REPO_URL="https://github.com/OpenACCUserGroup/OpenACCV-V"
+REPO_PATH="${OPENACC_VV_PATH:-target/openacc_vv}"
+TESTS_DIR="Tests"
+PYTHON="${PYTHON:-python3}"
+MAX_DISPLAY_FAILURES=10
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo "========================================="
+echo "  OpenACCV-V Round-Trip Validation"
+echo "========================================="
+echo
+
+echo "Checking for required tools..."
+for tool in cargo "$PYTHON"; do
+    if ! command -v "$tool" &>/dev/null; then
+        echo -e "${RED}Error: $tool not found in PATH${NC}"
+        exit 1
+    fi
+done
+echo -e "${GREEN}✓${NC} All required tools found"
+echo
+
+if [ ! -d "$REPO_PATH" ]; then
+    echo "OpenACCV-V not found at $REPO_PATH"
+    echo "Cloning from $REPO_URL..."
+    git clone --depth 1 "$REPO_URL" "$REPO_PATH" || {
+        echo -e "${RED}Failed to clone OpenACCV-V${NC}"
+        exit 1
+    }
+    echo -e "${GREEN}✓${NC} Cloned successfully"
+    echo
+elif [ ! -d "$REPO_PATH/$TESTS_DIR" ]; then
+    echo -e "${RED}Error: $REPO_PATH exists but $TESTS_DIR/ not found${NC}"
+    exit 1
+else
+    echo "Using existing OpenACCV-V at $REPO_PATH"
+    echo
+fi
+
+echo "Building roup_roundtrip binary..."
+cargo build --quiet --bin roup_roundtrip || {
+    echo -e "${RED}Failed to build roup_roundtrip${NC}"
+    exit 1
+}
+echo -e "${GREEN}✓${NC} Binary built"
+echo
+
+ROUNDTRIP_BIN="./target/debug/roup_roundtrip"
+
+REPORT=$(mktemp)
+if "$PYTHON" scripts/openacc_vv_runner.py \
+    --tests-dir "$REPO_PATH/$TESTS_DIR" \
+    --roundtrip-bin "$ROUNDTRIP_BIN" \
+    --max-failures "$MAX_DISPLAY_FAILURES" \
+    > "$REPORT" 2>&1; then
+    cat "$REPORT"
+    rm -f "$REPORT"
+    exit 0
+else
+    cat "$REPORT"
+    echo -e "${RED}✗ Some directives failed to round-trip${NC}"
+    rm -f "$REPORT"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- add an automated OpenACCV-V validation harness and documentation for running it
- teach the round-trip CLI to auto-detect OpenACC/Fortran directives and emit matching prefixes
- extend the OpenACC parser with routine-specific handling to support the new corpus

## Testing
- ./test_openacc_vv.sh

------
https://chatgpt.com/codex/tasks/task_e_68f44983ea4c832f9f66b878864cfa87