### PR TITLE
Add OpenACCV-V validation harness

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -134,6 +134,29 @@ Runs all 19 test categories on your current Rust version:
 - Missing required files = FAIL
 - All tests are MANDATORY
 
+### test_openacc_vv.sh - OpenACC round-trip validation
+
+Validates ROUP against the upstream
+[OpenACCV-V](https://github.com/OpenACCUserGroup/OpenACCV-V) compatibility
+suite. The helper clones (or reuses) the test repository, builds the
+`roup_roundtrip` binary, extracts every `#pragma acc` / `!$acc` directive and
+checks that ROUP round-trips each directive losslessly.
+
+```bash
+# Default clone lives in target/openacc_vv
+./test_openacc_vv.sh
+
+# Reuse an existing checkout and pick a specific clang toolchain
+OPENACC_VV_PATH=$HOME/src/OpenACCV-V \
+CLANG=clang-16 \
+CLANG_FORMAT=clang-format-16 \
+    ./test_openacc_vv.sh
+```
+
+Requirements: `cargo`, `git`, `clang` and `clang-format`. See
+[`docs/OPENACC_VV.md`](docs/OPENACC_VV.md) for full details and troubleshooting
+tips.
+
 ### test_rust_versions.sh - Multi-Version Testing
 
 Tests your code against multiple Rust versions to catch version-specific issues **before** CI fails.

--- a/docs/OPENACC_VV.md
+++ b/docs/OPENACC_VV.md
@@ -1,0 +1,55 @@
+# OpenACC validation with OpenACCV-V
+
+The [`test_openacc_vv.sh`](../test_openacc_vv.sh) helper runs the official
+[OpenACCV-V](https://github.com/OpenACCUserGroup/OpenACCV-V) validation suite
+against ROUP's OpenACC parser. The workflow mirrors the existing OpenMP_VV
+round-trip script and provides a reproducible way to triage parser regressions.
+
+## What the script does
+
+1. Clones the OpenACCV-V repository (or reuses an existing clone supplied via
+   `OPENACC_VV_PATH`).
+2. Builds the `roup_roundtrip` binary with Cargo.
+3. Preprocesses every C/C++ test with `clang -E` to expand macros and includes.
+4. Extracts every `#pragma acc` directive from the C/C++ sources and every
+   `!$acc` directive from the Fortran test cases.
+5. Pipes each directive through `roup_roundtrip` with the OpenACC dialect
+   enabled.
+6. Normalises both the original and round-tripped directive (`clang-format` for
+   C/C++, `awk` whitespace collapsing for Fortran) and compares the results.
+7. Emits a colourised summary with per-directive failure details when
+   mismatches occur.
+
+## Requirements
+
+* `clang` and `clang-format` (any version that understands `-E` and basic
+  formatting is fine). Override with `CLANG=/path` or
+  `CLANG_FORMAT=/path` if necessary.
+* `cargo` to build the ROUP binaries.
+* `git` to fetch OpenACCV-V (skip cloning by pointing `OPENACC_VV_PATH` at an
+  existing checkout).
+
+## Usage
+
+```bash
+# Run with the default clone target (target/openacc_vv)
+./test_openacc_vv.sh
+
+# Reuse a manual clone and pick a specific clang toolchain
+OPENACC_VV_PATH=$HOME/src/OpenACCV-V \
+CLANG=clang-16 \
+CLANG_FORMAT=clang-format-16 \
+    ./test_openacc_vv.sh
+```
+
+The script exits non-zero if any directive fails to round-trip or if a parse
+error occurs. Failure details include the source file, the offending directive
+and either the parse error from `roup_roundtrip` or the normalised output that
+failed comparison.
+
+## Updating ROUP
+
+When ROUP gains new OpenACC syntax support, run the script to verify that the
+entire OpenACCV-V test suite still round-trips cleanly. Any mismatch should be
+investigated and either fixed in the parser or documented as a known
+limitation before shipping.

--- a/src/bin/roup_roundtrip.rs
+++ b/src/bin/roup_roundtrip.rs
@@ -1,5 +1,76 @@
-use roup::parser::openmp;
+use roup::lexer::Language;
+use roup::parser::{openacc, openmp, Dialect};
+use std::env;
 use std::io::{self, Read};
+
+fn detect_language(input: &str) -> Language {
+    let trimmed = input.trim_start();
+
+    if trimmed.starts_with('#') {
+        Language::C
+    } else if trimmed.len() >= 2
+        && matches!(
+            &trimmed.as_bytes()[..2],
+            [b'c', b'$'] | [b'C', b'$'] | [b'*', b'$'] | [b'!', b'$']
+        )
+    {
+        // Fixed-form allows C$ACC / *$ACC / !$ACC sentinels in columns 1-6
+        // Free-form directives also start with !$ACC once whitespace is trimmed.
+        if trimmed.to_ascii_lowercase().starts_with('c') || trimmed.starts_with('*') {
+            Language::FortranFixed
+        } else {
+            Language::FortranFree
+        }
+    } else {
+        Language::C
+    }
+}
+
+fn parse_language_from_env(value: Option<String>) -> Result<Option<Language>, String> {
+    match value {
+        Some(raw) => match raw.to_ascii_lowercase().as_str() {
+            "c" => Ok(Some(Language::C)),
+            "fortran-free" => Ok(Some(Language::FortranFree)),
+            "fortran-fixed" => Ok(Some(Language::FortranFixed)),
+            other => Err(format!("Unsupported ROUP_LANGUAGE value: {}", other)),
+        },
+        None => Ok(None),
+    }
+}
+
+fn parse_dialect_from_env(value: Option<String>) -> Result<Dialect, String> {
+    match value {
+        Some(raw) => match raw.to_ascii_lowercase().as_str() {
+            "openmp" => Ok(Dialect::OpenMp),
+            "openacc" => Ok(Dialect::OpenAcc),
+            other => Err(format!("Unsupported ROUP_DIALECT value: {}", other)),
+        },
+        None => Ok(Dialect::OpenMp),
+    }
+}
+
+fn determine_prefix(input: &str, language: Language) -> String {
+    let trimmed = input.trim_start();
+
+    match language {
+        Language::C => {
+            let mut parts = trimmed.split_whitespace();
+            let first = parts.next().unwrap_or("#pragma");
+            let second = parts.next().unwrap_or("acc");
+
+            if first.eq_ignore_ascii_case("#pragma") {
+                format!("{} {}", first, second)
+            } else {
+                first.to_string()
+            }
+        }
+        Language::FortranFree | Language::FortranFixed => trimmed
+            .split_whitespace()
+            .next()
+            .unwrap_or("!$acc")
+            .to_string(),
+    }
+}
 
 fn main() {
     let mut input = String::new();
@@ -14,14 +85,43 @@ fn main() {
         std::process::exit(1);
     }
 
-    let parser = openmp::parser();
+    let dialect = match parse_dialect_from_env(env::var("ROUP_DIALECT").ok()) {
+        Ok(dialect) => dialect,
+        Err(err) => {
+            eprintln!("{}", err);
+            std::process::exit(1);
+        }
+    };
+
+    let language = match parse_language_from_env(env::var("ROUP_LANGUAGE").ok()) {
+        Ok(Some(language)) => language,
+        Ok(None) => detect_language(trimmed),
+        Err(err) => {
+            eprintln!("{}", err);
+            std::process::exit(1);
+        }
+    };
+
+    let parser = match dialect {
+        Dialect::OpenMp => openmp::parser(),
+        Dialect::OpenAcc => openacc::parser(),
+    }
+    .with_language(language);
+
     match parser.parse(trimmed) {
         Ok((rest, directive)) => {
             if !rest.trim().is_empty() {
                 eprintln!("Unparsed trailing input: '{}'", rest.trim());
                 std::process::exit(1);
             }
-            println!("{}", directive.to_pragma_string());
+            let output = match dialect {
+                Dialect::OpenMp => directive.to_pragma_string(),
+                Dialect::OpenAcc => {
+                    let prefix = determine_prefix(trimmed, language);
+                    directive.to_pragma_string_with_prefix(&prefix)
+                }
+            };
+            println!("{}", output);
         }
         Err(e) => {
             eprintln!("Parse error: {:?}", e);

--- a/test_openacc_vv.sh
+++ b/test_openacc_vv.sh
@@ -1,0 +1,245 @@
+#!/bin/bash
+#
+# test_openacc_vv.sh - Round-trip OpenACC pragmas from OpenACCV-V through ROUP
+#
+# This script validates ROUP by:
+# 1. Cloning the OpenACCV-V validation suite (on-demand)
+# 2. Preprocessing all C/C++ test files with clang
+# 3. Extracting OpenACC directives from C/C++ and Fortran tests
+# 4. Round-tripping each directive through ROUP's parser
+# 5. Comparing normalized input vs output (clang-format for C/C++, awk for Fortran)
+# 6. Reporting pass/fail statistics
+#
+# Usage:
+#   ./test_openacc_vv.sh                          # Auto-clone to target/openacc_vv
+#   OPENACC_VV_PATH=/path ./test_openacc_vv.sh   # Use existing clone
+#   CLANG=clang-16 ./test_openacc_vv.sh          # Use specific clang version
+
+set -euo pipefail
+
+REPO_URL="https://github.com/OpenACCUserGroup/OpenACCV-V"
+REPO_PATH="${OPENACC_VV_PATH:-target/openacc_vv}"
+TESTS_DIR="Tests"
+CLANG="${CLANG:-clang}"
+CLANG_FORMAT="${CLANG_FORMAT:-clang-format}"
+ROUNDTRIP_BIN="./target/debug/roup_roundtrip"
+MAX_DISPLAY_FAILURES=10
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+total_files=0
+files_with_directives=0
+total_directives=0
+passed=0
+failed=0
+parse_errors=0
+
+declare -a failure_files=()
+declare -a failure_directives=()
+declare -a failure_reasons=()
+
+echo "========================================="
+echo "  OpenACCV-V Round-Trip Validation"
+echo "========================================="
+echo ""
+
+echo "Checking for required tools..."
+for tool in "$CLANG" "$CLANG_FORMAT" cargo git; do
+    if ! command -v "$tool" &>/dev/null; then
+        echo -e "${RED}Error: $tool not found in PATH${NC}"
+        exit 1
+    fi
+done
+echo -e "${GREEN}✓${NC} All required tools found"
+echo ""
+
+if [ ! -d "$REPO_PATH" ]; then
+    echo "OpenACCV-V not found at $REPO_PATH"
+    echo "Cloning from $REPO_URL..."
+    git clone --depth 1 "$REPO_URL" "$REPO_PATH" || {
+        echo -e "${RED}Failed to clone OpenACCV-V${NC}"
+        exit 1
+    }
+    echo -e "${GREEN}✓${NC} Cloned successfully"
+    echo ""
+elif [ ! -d "$REPO_PATH/$TESTS_DIR" ]; then
+    echo -e "${RED}Error: $REPO_PATH exists but $TESTS_DIR/ not found${NC}"
+    exit 1
+else
+    echo "Using existing OpenACCV-V at $REPO_PATH"
+    echo ""
+fi
+
+echo "Building roup_roundtrip binary..."
+cargo build --quiet --bin roup_roundtrip || {
+    echo -e "${RED}Failed to build roup_roundtrip${NC}"
+    exit 1
+}
+echo -e "${GREEN}✓${NC} Binary built"
+echo ""
+
+echo "Finding test files in $REPO_PATH/$TESTS_DIR..."
+mapfile -t source_files < <(find "$REPO_PATH/$TESTS_DIR" -type f \( -name "*.c" -o -name "*.cpp" -o -name "*.h" -o -name "*.F90" -o -name "*.f90" -o -name "*.F" -o -name "*.f" \) | sort)
+total_files=${#source_files[@]}
+echo "Found $total_files files"
+echo ""
+
+echo "Processing files..."
+echo ""
+
+for file in "${source_files[@]}"; do
+    has_directive=false
+
+    case "$file" in
+        *.c|*.cpp|*.h)
+            preprocessed=$("$CLANG" -E -P -CC -I"$(dirname "$file")" "$file" 2>/dev/null || true)
+            if [ -z "$preprocessed" ]; then
+                continue
+            fi
+
+            mapfile -t pragmas < <(echo "$preprocessed" | grep -E '^[[:space:]]*#pragma[[:space:]]+acc' || true)
+            if [ ${#pragmas[@]} -eq 0 ]; then
+                continue
+            fi
+            has_directive=true
+
+            for pragma in "${pragmas[@]}"; do
+                total_directives=$((total_directives + 1))
+
+                if ! roundtrip_output=$(printf '%s
+' "$pragma" | ROUP_DIALECT=openacc ROUP_LANGUAGE=c "$ROUNDTRIP_BIN" 2>&1); then
+                    parse_errors=$((parse_errors + 1))
+                    failed=$((failed + 1))
+                    failure_files+=("$file")
+                    failure_directives+=("$pragma")
+                    failure_reasons+=("Parse error: $roundtrip_output")
+                    continue
+                fi
+
+                roundtrip="$roundtrip_output"
+
+                if ! original_formatted=$(printf '%s
+' "$pragma" | "$CLANG_FORMAT" 2>/dev/null); then
+                    original_formatted="$pragma"
+                fi
+
+                if ! roundtrip_formatted=$(printf '%s
+' "$roundtrip" | "$CLANG_FORMAT" 2>/dev/null); then
+                    roundtrip_formatted="$roundtrip"
+                fi
+
+                if [ "$original_formatted" = "$roundtrip_formatted" ]; then
+                    passed=$((passed + 1))
+                else
+                    failed=$((failed + 1))
+                    failure_files+=("$file")
+                    failure_directives+=("$pragma")
+                    clean_roundtrip=$(printf '%s' "$roundtrip" | tr '\n' ' ')
+                    failure_reasons+=("Mismatch: got '$clean_roundtrip'")
+                fi
+            done
+            ;;
+        *.F90|*.f90|*.F|*.f)
+            mapfile -t directives < <(grep -i '^[[:space:]]*!\$acc' "$file" || true)
+            if [ ${#directives[@]} -eq 0 ]; then
+                continue
+            fi
+            has_directive=true
+
+            for directive in "${directives[@]}"; do
+                total_directives=$((total_directives + 1))
+
+                if ! roundtrip_output=$(printf '%s
+' "$directive" | ROUP_DIALECT=openacc ROUP_LANGUAGE=fortran-free "$ROUNDTRIP_BIN" 2>&1); then
+                    parse_errors=$((parse_errors + 1))
+                    failed=$((failed + 1))
+                    failure_files+=("$file")
+                    failure_directives+=("$directive")
+                    failure_reasons+=("Parse error: $roundtrip_output")
+                    continue
+                fi
+
+                roundtrip="$roundtrip_output"
+                original_normalized=$(printf '%s
+' "$directive" | awk '{ $1=$1; print }')
+                roundtrip_normalized=$(printf '%s
+' "$roundtrip" | awk '{ $1=$1; print }')
+
+                if [ "$original_normalized" = "$roundtrip_normalized" ]; then
+                    passed=$((passed + 1))
+                else
+                    failed=$((failed + 1))
+                    failure_files+=("$file")
+                    failure_directives+=("$directive")
+                    clean_roundtrip=$(printf '%s' "$roundtrip" | tr '\n' ' ')
+                    failure_reasons+=("Mismatch: got '$clean_roundtrip'")
+                fi
+            done
+            ;;
+        *)
+            ;;
+    esac
+
+    if [ "$has_directive" = true ]; then
+        files_with_directives=$((files_with_directives + 1))
+    fi
+done
+
+echo ""
+echo "========================================="
+echo "  Results"
+echo "========================================="
+echo ""
+echo "Files processed:        $total_files"
+echo "Files with directives:  $files_with_directives"
+echo "Total directives:       $total_directives"
+echo ""
+
+if [ $total_directives -eq 0 ]; then
+    echo -e "${YELLOW}Warning: No directives found to test${NC}"
+    exit 0
+fi
+
+pass_rate=$(awk "BEGIN {printf \"%.1f\", ($passed * 100.0) / $total_directives}")
+
+echo -e "${GREEN}Passed:${NC}                $passed"
+echo -e "${RED}Failed:${NC}                $failed"
+echo "  Parse errors:         $parse_errors"
+echo "  Mismatches:           $((failed - parse_errors))"
+echo ""
+echo "Success rate:           ${pass_rate}%"
+echo ""
+
+if [ $failed -gt 0 ]; then
+    echo "========================================="
+    echo "  Failure Details (showing first $MAX_DISPLAY_FAILURES)"
+    echo "========================================="
+    echo ""
+
+    display_count=0
+    for i in "${!failure_files[@]}"; do
+        if [ $display_count -ge $MAX_DISPLAY_FAILURES ]; then
+            remaining=$((failed - MAX_DISPLAY_FAILURES))
+            echo "... and $remaining more failures"
+            break
+        fi
+
+        echo -e "${YELLOW}[$((i + 1))]${NC} ${failure_files[$i]}"
+        echo "    Directive: ${failure_directives[$i]}"
+        echo "    Reason:    ${failure_reasons[$i]}"
+        echo ""
+
+        display_count=$((display_count + 1))
+    done
+fi
+
+if [ $failed -eq 0 ]; then
+    echo -e "${GREEN}✓ All directives round-tripped successfully!${NC}"
+    exit 0
+else
+    echo -e "${RED}✗ Some directives failed to round-trip${NC}"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- extend `roup_roundtrip` so it can parse both OpenMP and OpenACC dialects based on environment configuration or automatic detection
- add an automated OpenACCV-V validation script that extracts C/C++ and Fortran directives and checks round-trips through ROUP
- document the new workflow in TESTING.md and a dedicated OpenACCV-V guide

## Testing
- cargo test --tests
- ./test_openacc_vv.sh *(fails: clang not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f44983ea4c832f9f66b878864cfa87