### PR TITLE
Add OpenACCV-V round-trip validation harness

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -468,6 +468,65 @@ The validation uses two simple components:
 
 This approach is simpler and more maintainable than complex Rust-only solutions.
 
+## OpenACCV-V Round-Trip Validation
+
+The [OpenACCV-V](https://github.com/OpenACCUserGroup/OpenACCV-V) suite exercises OpenACC directives across C, C++, and Fortran sources. ROUP round-trips every directive through the OpenACC parser to guarantee semantic fidelity.
+
+### How It Works
+
+1. **Clone OpenACCV-V** (automatically on first run into `target/openacc_vv`).
+2. **Collect directives** from `.c`, `.cpp`, `.F90`, `.F`, and related files under `Tests/`.
+3. **Normalize optional punctuation** (commas between clauses, spacing before parentheses) without altering meaning.
+4. **Round-trip each directive** using the `roup_roundtrip_acc` binary.
+5. **Re-parse canonical output** to verify the structure matches the original directive.
+6. **Emit JSON metrics** to `target/openacc_vv_report.json` alongside the console summary.
+
+### Running the Test
+
+```bash
+# Run OpenACCV-V validation (auto-clones repository if needed)
+./test_openacc_vv.sh
+
+# Or as part of the comprehensive suite
+./test.sh  # Includes OpenACCV-V as section 20
+```
+
+### Using an Existing Clone
+
+```bash
+# Reuse an existing checkout
+OPENACC_VV_PATH=/path/to/OpenACCV-V ./test_openacc_vv.sh
+```
+
+### Example Output
+
+```
+=========================================
+  OpenACCV-V Round-Trip Validation
+=========================================
+
+Files processed:        1336
+Files with directives:  1304
+Total directives:       9417
+
+Passed:                9417
+Failed:                0
+  Parse errors:        0
+  Mismatches:          0
+
+Success rate:          100.0%
+
+JSON report written to target/openacc_vv_report.json
+```
+
+### Requirements
+
+- **python3** – Directive harvesting and reporting (`scripts/run_openacc_vv.py`).
+- **cargo** – Builds the `roup_roundtrip_acc` binary.
+- **git** – Clones OpenACCV-V when no local checkout exists.
+
+The script exits with a non-zero status if any directive fails to round-trip.
+
 ## FAQ
 
 **Q: Why MSRV + stable instead of testing many versions?**

--- a/scripts/run_openacc_vv.py
+++ b/scripts/run_openacc_vv.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Run OpenACCV-V directives through ROUP's OpenACC round-trip binary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+
+@dataclass
+class DirectiveCase:
+    file_path: Path
+    line: int
+    language: str
+    original: str
+
+
+LANGUAGE_MAP = {
+    ".c": "c",
+    ".cc": "c",
+    ".cpp": "c",
+    ".cxx": "c",
+    ".C": "c",
+    ".F90": "fortran-free",
+    ".f90": "fortran-free",
+    ".F95": "fortran-free",
+    ".f95": "fortran-free",
+    ".F03": "fortran-free",
+    ".f03": "fortran-free",
+    ".F08": "fortran-free",
+    ".f08": "fortran-free",
+    ".F": "fortran-fixed",
+    ".f": "fortran-fixed",
+    ".FOR": "fortran-fixed",
+    ".for": "fortran-fixed",
+}
+
+PRAGMA_REGEX = re.compile(r"^\s*#\s*pragma\s+acc\b", re.IGNORECASE)
+FORTRAN_SENTINEL_REGEX = re.compile(r"^\s*[!c\*]\$\s*acc", re.IGNORECASE)
+CLAUSE_COMMA_REGEX = re.compile(r"\)\s*,\s*(?=[A-Za-z])")
+SPACE_BEFORE_PAREN_REGEX = re.compile(r"(?<=[A-Za-z_])\s+\(")
+
+
+class TestStats:
+    def __init__(self, tests_root: Path) -> None:
+        self.tests_root = tests_root
+        self.total_files = 0
+        self.files_with_directives = 0
+        self.total_directives = 0
+        self.passed = 0
+        self.failed = 0
+        self.parse_errors = 0
+        self.mismatches = 0
+        self.failures: List[Tuple[DirectiveCase, str, str]] = []
+
+    def record_pass(self) -> None:
+        self.total_directives += 1
+        self.passed += 1
+
+    def record_parse_error(self, case: DirectiveCase, stderr: str) -> None:
+        self.total_directives += 1
+        self.failed += 1
+        self.parse_errors += 1
+        if len(self.failures) < 20:
+            self.failures.append((case, "Parse error", stderr.strip()))
+
+    def record_mismatch(self, case: DirectiveCase, expected: str, actual: str) -> None:
+        self.total_directives += 1
+        self.failed += 1
+        self.mismatches += 1
+        if len(self.failures) < 20:
+            self.failures.append((case, expected, actual))
+
+    def relative_path(self, case: DirectiveCase) -> str:
+        try:
+            return str(case.file_path.relative_to(self.tests_root))
+        except ValueError:
+            return str(case.file_path)
+
+
+def discover_files(tests_dir: Path) -> Iterable[Path]:
+    for path in sorted(tests_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        if path.suffix in LANGUAGE_MAP:
+            yield path
+
+
+def gather_directives(path: Path) -> List[DirectiveCase]:
+    language = LANGUAGE_MAP.get(path.suffix)
+    if not language:
+        return []
+
+    cases: List[DirectiveCase] = []
+    lines = path.read_text(encoding="utf-8", errors="ignore").splitlines()
+    idx = 0
+    while idx < len(lines):
+        line = lines[idx]
+        if language == "c":
+            if not PRAGMA_REGEX.search(line):
+                idx += 1
+                continue
+            directive_lines = [line.rstrip("\n")]
+            while directive_lines[-1].rstrip().endswith("\\"):
+                idx += 1
+                if idx >= len(lines):
+                    break
+                directive_lines.append(lines[idx].rstrip("\n"))
+            original = "\n".join(directive_lines)
+            start_line = idx - (len(directive_lines) - 1) + 1
+            cases.append(DirectiveCase(path, start_line, language, original))
+            idx += 1
+            continue
+
+        # Fortran
+        if not FORTRAN_SENTINEL_REGEX.search(line):
+            idx += 1
+            continue
+        directive_lines = [line.rstrip("\n")]
+        while directive_lines[-1].rstrip().endswith("&"):
+            idx += 1
+            if idx >= len(lines):
+                break
+            directive_lines.append(lines[idx].rstrip("\n"))
+        original = "\n".join(directive_lines)
+        start_line = idx - (len(directive_lines) - 1) + 1
+        cases.append(DirectiveCase(path, start_line, language, original))
+        idx += 1
+
+    return cases
+
+
+def normalize(text: str) -> str:
+    text = CLAUSE_COMMA_REGEX.sub(") ", text)
+    text = SPACE_BEFORE_PAREN_REGEX.sub("(", text)
+    collapsed = re.sub(r"\s+", " ", text.strip())
+    return collapsed.lower()
+
+
+def prepare_input(text: str) -> str:
+    text = CLAUSE_COMMA_REGEX.sub(") ", text)
+    text = SPACE_BEFORE_PAREN_REGEX.sub("(", text)
+    return text
+
+
+def run_case(case: DirectiveCase, binary: Path) -> Tuple[bool, str, str]:
+    prepared = prepare_input(case.original)
+    proc = subprocess.run(
+        [str(binary), "--lang", case.language],
+        input=prepared,
+        text=True,
+        capture_output=True,
+    )
+
+    if proc.returncode != 0:
+        return False, proc.stderr.strip(), ""
+
+    output = proc.stdout.strip()
+    original_norm = normalize(case.original)
+    output_norm = normalize(output)
+    success = original_norm == output_norm
+    return success, output, output_norm
+
+
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tests-dir", type=Path, required=True)
+    parser.add_argument("--binary", type=Path, required=True)
+    parser.add_argument("--json-output", type=Path)
+    args = parser.parse_args(argv)
+
+    tests_dir: Path = args.tests_dir.resolve()
+    binary: Path = args.binary
+
+    if not binary.exists():
+        print(f"Error: round-trip binary not found at {binary}", file=sys.stderr)
+        return 2
+
+    stats = TestStats(tests_dir)
+    for path in discover_files(tests_dir):
+        stats.total_files += 1
+        directives = gather_directives(path)
+        if not directives:
+            continue
+        stats.files_with_directives += 1
+        for case in directives:
+            success, detail, normalized = run_case(case, binary)
+            if success:
+                stats.record_pass()
+            else:
+                if (
+                    detail.startswith("Parse error")
+                    or "Parse error" in detail
+                    or "Unparsed trailing input" in detail
+                ):
+                    stats.record_parse_error(case, detail)
+                else:
+                    display_detail = detail if detail else normalized
+                    stats.record_mismatch(
+                        case,
+                        normalize(case.original),
+                        display_detail,
+                    )
+
+    report = {
+        "files_processed": stats.total_files,
+        "files_with_directives": stats.files_with_directives,
+        "total_directives": stats.total_directives,
+        "passed": stats.passed,
+        "failed": stats.failed,
+        "parse_errors": stats.parse_errors,
+        "mismatches": stats.mismatches,
+        "failures": [
+            {
+                "file": stats.relative_path(case),
+                "line": case.line,
+                "language": case.language,
+                "reason": reason,
+                "detail": detail,
+                "original": case.original,
+            }
+            for case, reason, detail in stats.failures
+        ],
+    }
+
+    if args.json_output:
+        args.json_output.write_text(json.dumps(report, indent=2))
+
+    print("=========================================")
+    print("  OpenACCV-V Round-Trip Validation")
+    print("=========================================")
+    print("")
+    print(f"Files processed:        {stats.total_files}")
+    print(f"Files with directives:  {stats.files_with_directives}")
+    print(f"Total directives:       {stats.total_directives}")
+    print("")
+
+    if stats.total_directives == 0:
+        print("Warning: No OpenACC directives found to test")
+        return 0
+
+    pass_rate = (stats.passed / stats.total_directives) * 100.0
+    print(f"Passed:                {stats.passed}")
+    print(f"Failed:                {stats.failed}")
+    print(f"  Parse errors:        {stats.parse_errors}")
+    print(f"  Mismatches:          {stats.mismatches}")
+    print("")
+    print(f"Success rate:          {pass_rate:.1f}%")
+    print("")
+
+    if stats.failures:
+        print("=========================================")
+        print("  Failure Details (first 20)")
+        print("=========================================")
+        print("")
+        for index, (case, reason, detail) in enumerate(stats.failures, start=1):
+            print(
+                f"[{index}] {stats.relative_path(case)}:{case.line} ({case.language})"
+            )
+            print(f"    Reason:   {reason}")
+            if detail:
+                print(f"    Detail:   {detail}")
+            print(f"    Original: {case.original.strip()}")
+            print("")
+
+    return 0 if stats.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/bin/roup_roundtrip_acc.rs
+++ b/src/bin/roup_roundtrip_acc.rs
@@ -1,0 +1,135 @@
+use std::env;
+use std::io::{self, Read};
+
+use roup::lexer::Language;
+use roup::parser::{openacc, Directive};
+
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("{err}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let args: Vec<String> = env::args().collect();
+    let mut language = Language::C;
+
+    let mut idx = 1;
+    while idx < args.len() {
+        match args[idx].as_str() {
+            "--lang" => {
+                idx += 1;
+                if idx >= args.len() {
+                    return Err("--lang requires a value".into());
+                }
+                language = parse_language(&args[idx])?;
+            }
+            other => {
+                return Err(format!("Unknown argument: {other}"));
+            }
+        }
+        idx += 1;
+    }
+
+    let mut input = String::new();
+    io::stdin()
+        .read_to_string(&mut input)
+        .map_err(|err| format!("Failed to read stdin: {err}"))?;
+
+    let raw_input = input.trim_end();
+    if raw_input.trim().is_empty() {
+        return Err("No input provided".into());
+    }
+
+    let parser = openacc::parser().with_language(language);
+
+    let parse_input = match language {
+        Language::C => raw_input.trim_start(),
+        Language::FortranFree | Language::FortranFixed => raw_input,
+    };
+
+    let (rest, directive) = parser
+        .parse(parse_input)
+        .map_err(|err| format!("Parse error: {err:?}"))?;
+
+    if !rest.trim().is_empty() {
+        return Err(format!("Unparsed trailing input: '{}'", rest.trim()));
+    }
+
+    let prefix = detect_prefix(raw_input, language);
+    let canonical = directive.to_pragma_string_with_prefix(&prefix);
+
+    verify_roundtrip(&canonical, language, &directive)?;
+
+    println!("{canonical}");
+
+    Ok(())
+}
+
+fn parse_language(value: &str) -> Result<Language, String> {
+    match value.to_ascii_lowercase().as_str() {
+        "c" | "c++" | "cpp" => Ok(Language::C),
+        "fortran-free" | "fortran" | "f90" => Ok(Language::FortranFree),
+        "fortran-fixed" | "fixed" | "f" => Ok(Language::FortranFixed),
+        other => Err(format!("Unsupported language '{other}'")),
+    }
+}
+
+fn detect_prefix(input: &str, language: Language) -> String {
+    let first_line = input.lines().next().unwrap_or(input);
+    let indent_len = first_line
+        .char_indices()
+        .find(|(_, ch)| !ch.is_whitespace())
+        .map(|(idx, _)| idx)
+        .unwrap_or(first_line.len());
+    let indent = &first_line[..indent_len];
+
+    match language {
+        Language::C => format!("{indent}#pragma acc"),
+        Language::FortranFree | Language::FortranFixed => {
+            let rest = &first_line[indent_len..];
+            let sentinel_end = rest
+                .char_indices()
+                .find(|(_, ch)| ch.is_whitespace() || *ch == '&')
+                .map(|(idx, _)| idx)
+                .unwrap_or(rest.len());
+            let sentinel = &rest[..sentinel_end];
+            let sentinel = if sentinel.is_empty() {
+                "!$acc"
+            } else {
+                sentinel
+            };
+            format!("{indent}{sentinel}")
+        }
+    }
+}
+
+fn verify_roundtrip(
+    canonical: &str,
+    language: Language,
+    original: &Directive<'_>,
+) -> Result<(), String> {
+    let parser = openacc::parser().with_language(language);
+    let parse_input = match language {
+        Language::C => canonical.trim_start(),
+        Language::FortranFree | Language::FortranFixed => canonical,
+    };
+
+    let (rest, reparsed) = parser
+        .parse(parse_input)
+        .map_err(|err| format!("Parse error during roundtrip validation: {err:?}"))?;
+
+    if !rest.trim().is_empty() {
+        return Err(format!(
+            "Unparsed trailing input after roundtrip: '{}'",
+            rest.trim()
+        ));
+    }
+
+    if *original != reparsed {
+        return Err("Roundtrip mismatch between original and reparsed directives".into());
+    }
+
+    Ok(())
+}

--- a/test.sh
+++ b/test.sh
@@ -396,7 +396,31 @@ else
 fi
 
 # ===================================================================
-# 20. All Features Test
+# 20. OpenACC_VV Round-Trip Validation (REQUIRED: 100% pass rate)
+# ===================================================================
+SECTION_NUM=$((SECTION_NUM + 1)); echo "=== $SECTION_NUM. OpenACC_VV Round-Trip Validation ==="
+openacc_vv_status="skipped"
+if command -v python3 &>/dev/null; then
+    echo -n "Running OpenACC_VV round-trip test (100% required)... "
+    if ./test_openacc_vv.sh > /tmp/test_openacc_vv.log 2>&1; then
+        echo -e "${GREEN}✓ PASS (100% success rate)${NC}"
+        openacc_vv_status="passed"
+        grep "Success rate:" /tmp/test_openacc_vv.log || true
+    else
+        echo -e "${RED}✗ FAIL - OpenACC_VV test script failed${NC}"
+        tail -50 /tmp/test_openacc_vv.log
+        exit 1
+    fi
+else
+    echo -e "${RED}✗ FAIL - python3 is REQUIRED for OpenACC_VV validation${NC}"
+    echo "   Install (Debian/Ubuntu): apt-get install python3"
+    echo "   Install (macOS): brew install python"
+    echo "   Install (Fedora/RHEL): dnf install python3"
+    exit 1
+fi
+
+# ===================================================================
+# 21. All Features Test
 # ===================================================================
 SECTION_NUM=$((SECTION_NUM + 1)); echo "=== $SECTION_NUM. All Features Test ==="
 echo -n "Running tests with --all-features... "
@@ -409,7 +433,7 @@ else
 fi
 
 # ===================================================================
-# 21. Benchmark Tests
+# 22. Benchmark Tests
 # ===================================================================
 SECTION_NUM=$((SECTION_NUM + 1)); echo "=== $SECTION_NUM. Benchmark Tests ==="
 if [ ! -d "benches" ]; then
@@ -432,10 +456,10 @@ fi
 # ===================================================================
 echo ""
 echo "========================================"
-if [ "$openmp_vv_status" = "passed" ]; then
-    echo -e "  ${GREEN}ALL 21 TEST CATEGORIES PASSED${NC}"
+if [ "$openmp_vv_status" = "passed" ] && [ "$openacc_vv_status" = "passed" ]; then
+    echo -e "  ${GREEN}ALL 22 TEST CATEGORIES PASSED${NC}"
 else
-    echo -e "  ${GREEN}20 TEST CATEGORIES PASSED${NC}"
+    echo -e "  ${GREEN}21 TEST CATEGORIES PASSED${NC}"
 fi
 echo "========================================"
 echo ""
@@ -454,6 +478,11 @@ if [ "$openmp_vv_status" = "passed" ]; then
     echo "  ✓ OpenMP_VV round-trip validation"
 elif [ "$openmp_vv_status" = "skipped" ]; then
     echo "  ⚠ OpenMP_VV round-trip validation (skipped)"
+fi
+if [ "$openacc_vv_status" = "passed" ]; then
+    echo "  ✓ OpenACC_VV round-trip validation"
+elif [ "$openacc_vv_status" = "skipped" ]; then
+    echo "  ⚠ OpenACC_VV round-trip validation (skipped)"
 fi
 echo "  ✓ All features tested"
 echo "  ✓ Benchmarks validated"

--- a/test_openacc_vv.sh
+++ b/test_openacc_vv.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# test_openacc_vv.sh - Validate OpenACC directives from OpenACCV-V using ROUP
+#
+# This script performs the following steps:
+# 1. Clones the OpenACCV-V repository (if not already present)
+# 2. Builds the `roup_roundtrip_acc` binary
+# 3. Runs all directives through the round-trip validator
+# 4. Prints a human-readable summary and writes a JSON report
+#
+# Usage:
+#   ./test_openacc_vv.sh
+#   OPENACC_VV_PATH=/path ./test_openacc_vv.sh
+#
+
+set -euo pipefail
+
+REPO_URL="https://github.com/OpenACCUserGroup/OpenACCV-V"
+REPO_PATH="${OPENACC_VV_PATH:-target/openacc_vv}"
+TESTS_DIR="Tests"
+ROUNDTRIP_BIN="./target/debug/roup_roundtrip_acc"
+REPORT_PATH="target/openacc_vv_report.json"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+mkdir -p "$(dirname "$REPORT_PATH")"
+
+cat <<'BANNER'
+=========================================
+  OpenACCV-V Round-Trip Validation
+=========================================
+BANNER
+
+# Check prerequisites
+for tool in cargo git python3; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo -e "${RED}Error: required tool '$tool' not found in PATH${NC}"
+        exit 1
+    fi
+done
+
+# Ensure repository exists
+if [ ! -d "$REPO_PATH" ]; then
+    echo "Cloning OpenACCV-V into $REPO_PATH..."
+    git clone --depth 1 "$REPO_URL" "$REPO_PATH"
+    echo -e "${GREEN}✓${NC} Clone complete"
+else
+    echo "Using existing OpenACCV-V repository at $REPO_PATH"
+fi
+
+if [ ! -d "$REPO_PATH/$TESTS_DIR" ]; then
+    echo -e "${RED}Error: Tests directory not found at $REPO_PATH/$TESTS_DIR${NC}"
+    exit 1
+fi
+
+# Build round-trip binary
+echo "Building roup_roundtrip_acc binary..."
+cargo build --quiet --bin roup_roundtrip_acc
+if [ ! -x "$ROUNDTRIP_BIN" ]; then
+    echo -e "${RED}Error: round-trip binary not found at $ROUNDTRIP_BIN${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✓${NC} Binary built"
+
+echo "Running OpenACC directive validation..."
+set +e
+python3 scripts/run_openacc_vv.py \
+    --tests-dir "$REPO_PATH/$TESTS_DIR" \
+    --binary "$ROUNDTRIP_BIN" \
+    --json-output "$REPORT_PATH"
+status=$?
+set -e
+
+echo ""
+echo "JSON report written to $REPORT_PATH"
+
+exit $status


### PR DESCRIPTION
## Summary
- add a `roup_roundtrip_acc` helper binary that round-trips OpenACC directives for validation
- create a Python-powered OpenACCV-V harness and shell wrapper to collect directives and verify 100% success
- document the new workflow in TESTING.md and integrate the check into `test.sh`

## Testing
- `cargo test`
- `./test_openacc_vv.sh`


------
https://chatgpt.com/codex/tasks/task_e_68f44983ea4c832f9f66b878864cfa87