### PR TITLE
feat(parser): normalize directive parameters and fix scan parsing

### DIFF
--- a/src/parser/openacc.rs
+++ b/src/parser/openacc.rs
@@ -232,7 +232,8 @@ fn parse_end_directive<'a>(
     // Store the directive being ended as a parameter
     let directive = directive_parts.join(" ");
     let (rest, clauses) = clause_registry.parse_sequence(rest)?;
-    let parameter = format!(" {}", directive);
+    // Store the directive token without presentation spacing; rendering should add spaces.
+    let parameter = directive.to_string();
 
     Ok((
         rest,


### PR DESCRIPTION
## Summary

This branch consolidates several parser and rendering fixes into a single commit.

### What it does
- Removes presentation spacing embedded in `Directive.parameter` values (no leading spaces stored anymore).
- Normalizes `cancel` and OpenACC parameter construction to store semantic parameter content only.
- Ensures the directive renderer inserts a separating space before parameters when needed (unless the parameter begins with '(' or already contains a leading space).
- Confirms `scan` directive parsing supports `exclusive(list)` and `inclusive(list)` and correctly parses any trailing clauses.
- Fixes minor Clippy warnings and formatting issues discovered during testing.

### Rationale
Storing presentation spacing inside semantic data caused round-trip mismatches (e.g. `#pragma omp scanexclusive(x)`) during validation. The canonical approach is to keep stored values free of presentation whitespace and let the rendering layer insert spacing.

### Tests
All checks in `./test.sh` pass locally (formatting, build, unit/integration tests, mdBook, compat tests, and OpenMP_VV/OpenACCV-V round-trips).

### Next steps
- Merge into `main` once reviewed. This is a low-risk, behavior-preserving change; rendering now ensures proper spacing and round-trips.

