### PR TITLE
Streamline documentation content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,42 @@
 # ROUP: Rust-based OpenMP Parser
 
-Rust-first parsing for OpenMP directives with C and C++ bindings.
+Rust-first parsing for OpenMP and OpenACC directives with Rust, C, and C++ bindings.
 
 [![Docs](https://img.shields.io/badge/docs-roup.ouankou.com-blue)](https://roup.ouankou.com)
 [![Status](https://img.shields.io/badge/status-experimental-orange)](https://github.com/ouankou/roup)
 
-> **Experimental:** APIs are still evolving. Expect breaking changes between releases.
+> **Experimental:** APIs may change between releases.
 
-## Quick start
+## Install
 
-### Rust
+### Rust crate
+
 ```toml
 [dependencies]
 roup = "0.5"
 ```
 
 ### C or C++
+
 ```bash
 cargo build --release
 # Link against target/release/libroup.{a,so,dylib}
 ```
 
-Need platform-specific notes? See the [building guide](https://roup.ouankou.com/building.html).
+Platform-specific notes live in the [building guide](https://roup.ouankou.com/building.html).
 
-## Why ROUP?
+## Highlights
 
-- **OpenMP 3.0–6.0 coverage**: directives, clauses, and combined forms.
-- **OpenACC 3.4 coverage**: full directive and clause matrix documented in
-  [`docs/OPENACC_SUPPORT.md`](docs/OPENACC_SUPPORT.md).
-- **Multi-language APIs**: idiomatic Rust plus C and C++17 bindings.
-- **Tight unsafe boundary**: the FFI layer is the only unsafe code.
-- **Thorough testing**: 620+ automated tests across languages.
-- **ompparser compatibility**: optional shim for existing consumers.
+- **OpenMP 3.0–6.0** directives, clauses, and combined forms.
+- **OpenACC 3.4** coverage with the full matrix in [`docs/OPENACC_SUPPORT.md`](docs/OPENACC_SUPPORT.md).
+- **Multi-language APIs** for idiomatic Rust and C/C++17 consumers.
+- **Isolated unsafe boundary**: the FFI layer contains the only unsafe code.
+- **Extensive testing** with over 600 automated checks across languages.
+- **Compatibility shims** for ompparser and accparser users.
 
 ## Documentation
 
-All guides live at [roup.ouankou.com](https://roup.ouankou.com):
+Guides, tutorials, and references are published at [roup.ouankou.com](https://roup.ouankou.com):
 
 - [Getting started](https://roup.ouankou.com/getting-started.html)
 - [Rust tutorial](https://roup.ouankou.com/rust-tutorial.html)
@@ -57,45 +58,28 @@ fn main() {
 }
 ```
 
-Additional C and C++ samples are available in [`examples/`](examples/).
+More Rust, C, and C++ samples are available in [`examples/`](examples/).
 
 ## Build and test
 
 ```bash
 cargo build --release
 cargo test
+./test.sh             # full local battery (requires optional tooling)
 ```
 
-The book can be rebuilt with `cargo doc --no-deps`.
+Rebuild the documentation site with `mdbook build docs/book`.
 
-## ompparser compatibility
+## Compatibility layers
 
-The optional layer in [`compat/ompparser/`](compat/ompparser/) exposes the same headers as the original ompparser project. Build
- it with `./compat/ompparser/build.sh` or follow the manual steps in
- [the compatibility guide](docs/book/src/ompparser-compat.md).
+[`compat/ompparser/`](compat/ompparser/) and [`compat/accparser/`](compat/accparser/) ship drop-in replacements for the original ompparser and accparser libraries. Use the provided `build.sh` wrappers or follow the book's compatibility chapters under [`docs/book/src/`](docs/book/src/).
 
 ## Contributing
 
-Contributions are welcome. Review the [contributing guide](https://roup.ouankou.com/contributing.html) for coding standards, te
-st expectations, and the pull-request workflow.
-
-## Learning Resources
-
-ROUP demonstrates Rust concepts from basics to advanced:
-
-- **Basics:** Structs, enums, pattern matching, ownership
-- **Intermediate:** Traits, generics, error handling, modules
-- **Advanced:** Parser combinators (nom), FFI, unsafe boundaries
-
-**For learners:**
-- Read the [Architecture Guide](https://roup.ouankou.com/architecture.html)
-- Study the [examples](examples/) directory
-- Check the commit history for evolution
-
----
+Contributions are welcome. See the [contributing guide](https://roup.ouankou.com/contributing.html) for coding standards, testing expectations, and the pull-request workflow.
 
 ## License
 
-BSD-3-Clause License - see [LICENSE](LICENSE) file for details.
+BSD-3-Clause — see [LICENSE](LICENSE) for details.
 
-**Copyright © 2024-2025 Anjia Wang**
+© 2024-2025 Anjia Wang

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,611 +1,79 @@
 # Testing Guide
 
-This document describes the testing infrastructure and how to ensure your changes work across all supported Rust versions.
+ROUP ships two helper scripts that mirror the continuous-integration setup. Run them before submitting a change to ensure the parser, compatibility layers, and documentation stay healthy.
 
-## Quick Start
-
-```bash
-# Run all local tests (current Rust version)
-./test.sh
-
-# Test MSRV and stable (recommended before PR)
-./test_rust_versions.sh
-
-# Test specific versions
-./test_rust_versions.sh 1.85 stable
-```
-
-## Rust Version Support Policy
-
-### MSRV + Stable Approach
-
-ROUP follows the standard Rust ecosystem practice of testing **MSRV (Minimum Supported Rust Version) + stable**:
-
-- **MSRV: 1.85.0**
-  - Minimum version supporting edition2024 (required for mdBook dependencies)
-  - Released February 2025
-  - Set in `Cargo.toml` as `rust-version = "1.85.0"`
-  - Only bumped when new language features or tooling requirements needed
-
-- **Stable: Latest stable release**
-  - Ensures compatibility with current Rust ecosystem
-  - Catches new lints and API changes early
-
-**Why This Approach?**
-
-- ✅ **Industry standard**: Most Rust crates use MSRV + stable
-- ✅ **edition2024 support**: 1.85 is first stable version with edition2024
-- ✅ **Lower maintenance**: Only 2 versions to track instead of 6
-- ✅ **Clear compatibility promise**: Users know minimum version required
-- ✅ **Fewer CI minutes**: 2×3 = 6 jobs instead of 6×3 = 18
-
-**CI Matrix:**
-- **Rust versions:** 1.85 (MSRV), stable (2 versions)
-- **Operating systems:** Ubuntu 24.04, Windows 2025, macOS 15 (3 OSes)
-- **Total combinations:** 6 jobs
-
-### When to Bump MSRV
-
-MSRV should only be bumped when:
-- ✅ You need a new language feature not available in current MSRV
-- ✅ A critical dependency requires a newer Rust version
-- ✅ Ubuntu LTS updates to a newer default Rust version
-
-MSRV should NOT be bumped for:
-- ❌ Clippy lint changes (fix the code instead)
-- ❌ "Nice to have" features
-- ❌ Following the latest Rust version
-
-**When bumping MSRV:**
-1. Update `Cargo.toml`: `rust-version = "1.XX.0"`
-2. Update `.github/workflows/ci.yml`: `version: ["1.XX", "stable"]`
-3. Update this documentation
-4. Document the reason in the commit message
-
-## Rust Version Configuration
-
-### CI Config - Single Source of Truth
-
-The **CI workflow file** (`.github/workflows/ci.yml`) is the **single source of truth** for Rust versions. The `test_rust_versions.sh` script **automatically parses** the CI config to extract the version list, ensuring local testing always matches CI exactly.
-
-**How it works:**
+## Essential commands
 
 ```bash
-# test_rust_versions.sh automatically reads from CI config
-$ ./test_rust_versions.sh
-
-# Internally, it parses:
-# .github/workflows/ci.yml
-#   version: ["1.85", "stable"]
-#
-# And tests those exact versions locally
+./test.sh                 # full local battery on the active toolchain
+./test_rust_versions.sh   # mirrors the CI Rust matrix (MSRV + stable)
+./test_rust_versions.sh 1.85 stable  # explicit versions when debugging
 ```
 
-**When updating MSRV:**
+## Supported Rust versions
 
-1. Update **TWO places** (kept in sync):
-   ```yaml
-   # .github/workflows/ci.yml
-   version: ["1.85", "stable"]
-   ```
+- **Minimum supported Rust version (MSRV): 1.85.0**
+  - Matches the `rust-version` entry in `Cargo.toml`.
+  - First stable release with Edition 2024 support required by the docs build.
+- **Latest stable**: tracked automatically by CI to catch new lints and regressions.
 
-   ```toml
-   # Cargo.toml
-   rust-version = "1.85.0"
-   ```
+When bumping the MSRV:
 
-2. Run `./test_rust_versions.sh` - automatically picks up the new version:
-   ```bash
-   $ ./test_rust_versions.sh
-   Testing against Rust versions: 1.85 stable
-   ```
+1. Update `Cargo.toml` and `.github/workflows/ci.yml` to reference the new version.
+2. Adjust this document and any release notes.
+3. Run `./test_rust_versions.sh` to ensure both versions pass locally.
 
-3. Update this TESTING.md documentation.
+## Script overview
 
-## Test Scripts
+### `test.sh`
 
-### test.sh - Comprehensive Local Testing
+Runs every mandatory check on the active toolchain:
 
-Runs all 22 test categories on your current Rust version:
+- Formatting, clippy (`-D warnings`), and warning sweeps.
+- Debug and release builds for all targets.
+- Unit, integration, doc, and all-target tests.
+- Example builds and runs for Rust, C, C++, and Fortran.
+- mdBook build and doctest (`mdbook build/test docs/book`).
+- Compatibility layers (`compat/ompparser` and `compat/accparser`).
+- Header generation, feature-gated tests, and benchmark compilation.
+- OpenMP_VV and OpenACC_VV round-trip validation with 100% required success when prerequisites are installed.
 
-1. Code formatting (`cargo fmt --check`)
-2. Debug build
-3. Release build
-4. Unit tests
-5. Integration tests
-6. Doc tests
-7. All tests together
-8. Examples build
-9. API documentation
-10. ompparser compatibility
-11. mdBook build
-12. mdBook tests
-13. C examples (build + run)
-14. C++ examples (build + run)
-15. Fortran examples
-16. Header verification
-17. Warning check (zero tolerance)
-18. Clippy lints (zero tolerance)
-19. OpenMP_VV round-trip validation (100% required)
-20. OpenACCV-V round-trip validation (100% required)
-21. All features test
-22. Benchmarks
+Most sections expect optional tooling (e.g., `clang`, `clang-format`, `mdbook`). Install the tools listed in the script header if a step fails due to missing dependencies.
 
-**Zero-Tolerance Policy:**
-- Any warning = FAIL
-- Missing required files = FAIL
-- All tests are MANDATORY
+### `test_rust_versions.sh`
 
-### test_rust_versions.sh - Multi-Version Testing
+Validates multiple toolchains by parsing the CI workflow for the Rust matrix (currently `1.85` and `stable`). For each version it runs:
 
-Tests your code against multiple Rust versions to catch version-specific issues **before** CI fails.
+1. `cargo fmt --check`
+2. `cargo clippy --all-targets -- -D warnings`
+3. `cargo build --all-targets`
+4. `cargo test --all-targets`
 
-**Why This Matters:**
+The script restores your original toolchain when it finishes. Pass explicit versions to focus on a subset, e.g. `./test_rust_versions.sh 1.85`.
 
-Clippy lints evolve across Rust versions. A lint that passes on stable might fail on MSRV (or vice versa). Examples:
-- **Rust 1.85+**: `clippy::needless_lifetimes` became stricter
-- **Rust 1.88+**: `clippy::uninlined_format_args` became stricter
-- **Your local version**: Might be different from CI matrix
+## Continuous integration
 
-**How It Works:**
+GitHub Actions executes the same checks across six jobs:
 
-1. Automatically parses CI config to get version list
-2. Uses `rustup` to install/switch between Rust versions
-3. Runs critical checks on each version:
-   - Format check
-   - Clippy with `-D warnings`
-   - Build
-   - Tests
-4. Reports which versions pass/fail
-5. Restores your original Rust version
+- **Rust versions:** `1.85` (MSRV) and `stable`.
+- **Operating systems:** Ubuntu 24.04, Windows 2025, and macOS 15.
 
-**Usage:**
+The build jobs cover formatting, clippy, debug/release builds, full tests, feature-gated tests, benchmark compilation, example builds, and compatibility layers. A follow-up docs job builds the API docs with warnings-as-errors and runs `mdbook build/test` before deploying to GitHub Pages on `main`.
 
-```bash
-# Test MSRV + stable (mirrors CI matrix)
-./test_rust_versions.sh
+## Validation suites
 
-# Test specific versions
-./test_rust_versions.sh 1.85 stable
+### OpenMP_VV
 
-# Test with custom versions (for debugging)
-./test_rust_versions.sh 1.85 1.86 1.87 stable
-```
+`./test_openmp_vv.sh` clones the [OpenMP Validation & Verification](https://github.com/OpenMP-Validation-and-Verification/OpenMP_VV) suite, normalises each pragma with `clang-format`, round-trips it through `roup_roundtrip`, and compares the results. Clang and clang-format must be available in `PATH`. The script fails if any pragma diverges or a parse error occurs.
 
-**When to Use:**
+### OpenACC_VV
 
-- ✅ Before creating a PR
-- ✅ After fixing clippy warnings
-- ✅ After making lifetime changes
-- ✅ When updating dependencies
-- ✅ When CI fails on a specific version
+`./test_openacc_vv.sh` exercises the [OpenACCV-V](https://github.com/OpenACCUserGroup/OpenACCV-V) suite across C, C++, and Fortran sources. It normalises directives internally, runs `roup_roundtrip --acc`, and reports any mismatches. Python 3 is required for the helper utilities.
 
-## CI Testing
+## Recommended workflow
 
-The GitHub Actions CI runs a focused matrix:
+1. `cargo fmt`
+2. `./test.sh`
+3. `./test_rust_versions.sh`
 
-**Matrix Dimensions:**
-- **Rust versions:** 1.85 (MSRV), stable (2 versions)
-- **Operating systems:** Ubuntu 24.04, Windows 2025, macOS 15 (3 OSes)
-- **Total combinations:** 6 jobs
-
-**CI Workflow:**
-
-1. **Build Job** (6 parallel jobs):
-   - Format check
-   - Clippy lints (`-D warnings`)
-   - Debug build
-   - Release build
-   - All tests
-   - All features test
-   - Benchmark validation
-   - C examples (Linux only)
-   - C++ examples (Linux only)
-   - Fortran examples (Linux only)
-   - Header verification (Linux only)
-   - ompparser compat (Linux only)
-
-2. **Docs Job** (runs after build):
-   - mdBook tests
-   - mdBook build
-   - API docs (`RUSTDOCFLAGS: "-D warnings"`)
-   - Examples build
-   - Deploy to GitHub Pages (main branch only)
-
-**Why Multiple OSes?**
-
-- Different OS = Different default compilers, different file paths, different behaviors
-- We want to ensure the code works **everywhere**
-
-## Catching Version-Specific Issues
-
-### The Problem
-
-Clippy lints change between Rust versions:
-- New lints are added
-- Existing lints become stricter
-- Some lints are deprecated
-
-**Real Examples:**
-- The `needless_lifetimes` lint was introduced/strictened in Rust 1.85
-- The `uninlined_format_args` lint became stricter in Rust 1.88
-
-### The Solution
-
-**Local Testing:**
-```bash
-# Before pushing, test against the CI version range
-./test_rust_versions.sh
-
-# If any version fails, fix the issue
-# The script will show you the exact error
-```
-
-**Understanding Failures:**
-
-When `test_rust_versions.sh` reports a failure:
-
-```
-✗ Rust 1.85: FAILED
-Clippy errors for Rust 1.85:
-error: the following explicit lifetimes could be elided: 'a
-  --> src/lexer.rs:255:36
-```
-
-This tells you:
-1. Which version failed (1.85)
-2. What failed (clippy)
-3. The exact error and location
-
-**Fixing Version-Specific Issues:**
-
-1. Check the clippy documentation for the lint
-2. Apply the suggested fix (often `cargo clippy --fix` works)
-3. Re-run `./test_rust_versions.sh` to verify
-4. Run `./test.sh` to ensure all other tests still pass
-
-## Best Practices
-
-### Before Committing
-
-```bash
-# 1. Format your code
-cargo fmt
-
-# 2. Run full test suite
-./test.sh
-
-# 3. Test against MSRV and stable
-./test_rust_versions.sh
-```
-
-### Before Creating a PR
-
-```bash
-# Test the full version matrix (mirrors CI)
-./test_rust_versions.sh
-```
-
-### When CI Fails
-
-1. **Check which version failed** in the CI logs
-2. **Install that version locally:**
-   ```bash
-   rustup install 1.85
-   rustup override set 1.85
-   ```
-3. **Run clippy to see the error:**
-   ```bash
-   cargo clippy --all-targets -- -D warnings
-   ```
-4. **Fix the issue** (try `cargo clippy --fix --allow-dirty` first)
-5. **Verify with test_rust_versions.sh:**
-   ```bash
-   ./test_rust_versions.sh 1.85
-   ```
-6. **Restore your normal version:**
-   ```bash
-   rustup override unset
-   ```
-
-## Understanding Test Output
-
-### test.sh Output
-
-```
-========================================
-  ROUP Comprehensive Test Suite
-========================================
-
-Environment:
-rustc 1.90.0 (1159e78c4 2025-09-14)
-clippy 0.1.90 (1159e78c47 2025-09-14)
-
-=== 1. Formatting Check ===
-Running cargo fmt --check... ✓ PASS
-...
-========================================
-  ALL 22 TEST CATEGORIES PASSED
-========================================
-```
-
-The "Environment" section shows which Rust/clippy version you're testing with. This helps identify if issues are version-related.
-
-### test_rust_versions.sh Output
-
-```
-========================================
-  Rust Version Compatibility Test
-========================================
-
-Testing against Rust versions: 1.85 stable
-
-========================================
-Testing Rust 1.85
-========================================
-  rustc: rustc 1.85.0 (a28077b28 2025-02-20)
-  clippy: clippy 0.1.85
-
-Running critical checks:
-  1. Format check... ✓
-  2. Clippy lints... ✗ FAILED
-
-Clippy errors for Rust 1.82:
-error: the following explicit lifetimes could be elided: 'a
-...
-
-========================================
-  Summary
-========================================
-Tested versions: 2
-Passed: 1
-Failed: 1
-
-Failed versions:
-  - 1.82 (clippy)
-```
-
-This clearly shows which version failed and why.
-
-## OpenMP_VV Round-Trip Validation
-
-ROUP can validate itself against the [OpenMP Validation & Verification (OpenMP_VV)](https://github.com/OpenMP-Validation-and-Verification/OpenMP_VV) test suite by round-tripping every pragma through the parser.
-
-### How It Works
-
-The validation process:
-
-1. **Clone OpenMP_VV** (automatically on first run to `target/openmp_vv`)
-2. **Find all C/C++ test files** in the `tests/` directory
-3. **Preprocess with clang** to expand macros and includes
-4. **Extract OpenMP pragmas** (lines starting with `#pragma omp`)
-5. **Round-trip each pragma**:
-   - Normalize original with `clang-format`
-   - Parse with ROUP → unparse to string
-   - Normalize round-tripped version with `clang-format`
-   - Compare with `diff`
-6. **Report statistics**: total pragmas, pass/fail counts, success rate
-
-### Running the Test
-
-```bash
-# Run OpenMP_VV validation (auto-clones repository if needed)
-./test_openmp_vv.sh
-
-# Or as part of the full test suite
-./test.sh  # Includes OpenMP_VV as section 18
-```
-
-### Using Existing Repository
-
-If you already have OpenMP_VV cloned elsewhere:
-
-```bash
-# Point to existing clone
-OPENMP_VV_PATH=/path/to/OpenMP_VV ./test_openmp_vv.sh
-
-# Use specific clang version
-CLANG=clang-15 CLANG_FORMAT=clang-format-15 ./test_openmp_vv.sh
-```
-
-### Example Output
-
-```
-=========================================
-  OpenMP_VV Round-Trip Validation
-=========================================
-
-Checking for required tools...
-✓ All required tools found
-
-Using existing OpenMP_VV at target/openmp_vv
-
-Building roup_roundtrip binary...
-✓ Binary built
-
-Finding C/C++ test files in target/openmp_vv/tests...
-Found 247 C/C++ files
-
-Processing files...
-
-=========================================
-  Results
-=========================================
-
-Files processed:        247
-Files with pragmas:     183
-Total pragmas:          1247
-
-Passed:                1189
-Failed:                58
-  Parse errors:         12
-  Mismatches:           46
-
-Success rate:           95.3%
-```
-
-### Requirements
-
-- **clang** - For preprocessing (macros, includes)
-- **clang-format** - For pragma normalization
-- **cargo** - To build the `roup_roundtrip` binary
-- **git** - To clone OpenMP_VV (if not already present)
-
-The test gracefully skips if clang/clang-format are not available.
-
-### Implementation Details
-
-The validation uses two simple components:
-
-1. **`roup_roundtrip` binary** (~30 lines of Rust):
-   - Reads one pragma from stdin
-   - Parses and unparses it
-   - Prints to stdout
-   - Exits with code 1 on parse error
-
-2. **`test_openmp_vv.sh` script** (~200 lines of bash):
-   - Orchestrates the entire workflow
-   - Uses standard Unix tools (find, grep, diff)
-   - Tracks statistics and formats output
-
-This approach is simpler and more maintainable than complex Rust-only solutions.
-
-## OpenACCV-V Round-Trip Validation
-
-ROUP can validate itself against the [OpenACCV-V](https://github.com/OpenACCUserGroup/OpenACCV-V) test suite by round-tripping every directive through the parser. The flow mirrors the OpenMP validation but supports both C/C++ `#pragma acc` and Fortran `!$acc` forms.
-
-### How It Works
-
-The validation process:
-
-1. **Clone OpenACCV-V** (automatically on first run to `target/openacc_vv`)
-2. **Find all C/C++/Fortran test files** in the `Tests/` directory
-3. **Extract OpenACC directives** (lines with `#pragma acc`, `!$acc`, `c$acc`, `*$acc`)
-4. **Round-trip each directive**:
-   - Normalize original with bash whitespace collapsing
-   - Parse with ROUP → unparse to string
-   - Normalize round-tripped version with bash
-   - Compare with string equality
-5. **Report statistics**: total directives, pass/fail counts, success rate
-
-### Running the Test
-
-```bash
-# Run OpenACCV-V validation (auto-clones repository if needed)
-./test_openacc_vv.sh
-
-# Or as part of the full test suite
-./test.sh  # Includes OpenACCV-V as section 20
-```
-
-### Using Existing Repository
-
-If you already have OpenACCV-V cloned elsewhere:
-
-```bash
-# Point to existing clone
-OPENACC_VV_PATH=/path/to/OpenACCV-V ./test_openacc_vv.sh
-```
-
-### Example Output
-
-```
-=========================================
-  OpenACCV-V Round-Trip Validation
-=========================================
-
-Checking for required tools...
-✓ All required tools found
-
-Using existing OpenACCV-V at target/openacc_vv
-
-Building roup_roundtrip binary...
-✓ Binary built
-
-Running OpenACCV-V validator...
-=========================================
-  OpenACCV-V Round-Trip Validation
-=========================================
-
-Files processed:        1336
-Files with pragmas:     1304
-Total pragmas:          9417
-
-Passed:                 9417
-Failed:                 0
-  Parse errors:         0
-  Mismatches:           0
-
-Success rate:           100.0%
-```
-
-### Requirements
-
-- **cargo** - To build the `roup_roundtrip` binary
-- **git** - To clone OpenACCV-V (if not already present)
-
-The test gracefully skips if requirements are not met.
-
-### Implementation Details
-
-The validation uses two simple components:
-
-1. **`roup_roundtrip --acc` binary** (~120 lines of Rust):
-   - Reads one directive from stdin
-   - Detects language (C/C++ or Fortran)
-   - Parses and unparses it
-   - Prints to stdout
-   - Exits with code 1 on parse error
-
-2. **`test_openacc_vv.sh` script** (~230 lines of bash):
-   - Orchestrates the entire workflow
-   - Uses standard Unix tools (find, grep, sed)
-   - Tracks statistics and formats output
-
-This approach is simpler and more maintainable than complex Rust-only solutions.
-
-## FAQ
-
-**Q: Why MSRV + stable instead of testing many versions?**
-A: This is the standard Rust ecosystem practice. It's lower maintenance, clearer to users, and sufficient for catching issues. If it works on MSRV and stable, it almost always works on versions in between.
-
-**Q: What is our MSRV and why?**
-A: 1.85.0 - it's the first stable Rust version supporting edition2024, which is required by mdBook dependencies (specifically the `ignore` crate 0.4.24+).
-
-**Q: When will MSRV be bumped?**
-A: Only when we need new language features or Ubuntu LTS updates its default. Not for clippy lints or "nice to have" features.
-
-**Q: Which versions should I test locally?**
-A: Run `./test_rust_versions.sh` which automatically tests MSRV (1.85) + stable.
-
-**Q: Do I need to test all 6 CI jobs locally?**
-A: No! `test_rust_versions.sh` tests multiple Rust versions but only on your OS. That's usually sufficient since most issues are version-related, not OS-related.
-
-**Q: What if I don't have rustup?**
-A: Install it from https://rustup.rs/ - it's the standard Rust toolchain manager and required for managing multiple versions.
-
-**Q: Can I skip version testing?**
-A: You can, but CI will catch the issue later. Testing locally saves you a round-trip to CI (faster feedback).
-
-**Q: What's the difference between test.sh and test_rust_versions.sh?**
-- `test.sh`: Comprehensive (22 categories) on YOUR current Rust version
-- `test_rust_versions.sh`: Critical checks (4 checks) on MULTIPLE Rust versions (MSRV + stable)
-
-Use both for maximum confidence!
-
-**Q: Can I test intermediate versions like 1.82 or 1.85?**
-A: Yes! While CI only tests MSRV + stable, you can test any version locally:
-```bash
-./test_rust_versions.sh 1.85 1.86 1.87 stable
-```
-This is useful when debugging version-specific issues.
-
-## Continuous Improvement
-
-This testing infrastructure is designed to catch issues early. If you encounter a new class of version-specific issue:
-
-1. Document it in this file
-2. Consider adding a specific check to test_rust_versions.sh
-3. Share the knowledge in PR comments
-
-Together we keep the code quality high! 🚀
+Fix issues as they appear, then rerun the affected command. Keeping the scripts green locally saves cycles when CI runs the same checks.

--- a/compat/accparser/README.md
+++ b/compat/accparser/README.md
@@ -1,184 +1,54 @@
-# ROUP accparser Compatibility Layer
+# ROUP accparser compatibility layer
 
-**Drop-in replacement for accparser using ROUP's OpenACC parser**
+This directory provides a drop-in replacement for the original [accparser](https://github.com/ouankou/accparser) library, powered by ROUP's OpenACC parser.
 
-## Overview
-
-This compatibility layer provides `libaccparser.so` - a drop-in replacement for the original [accparser](https://github.com/ouankou/accparser) library, but powered by ROUP's fast Rust-based parser instead of ANTLR4.
-
-**Key Benefits:**
-- ✅ **Zero ANTLR4 dependency** - no need to install antlr4 runtime or toolchain
-- ✅ **Same API** - works with existing accparser-based code without changes
-- ✅ **Faster parsing** - ROUP's hand-written parser outperforms generated ANTLR code
-- ✅ **Better error handling** - clearer error messages and recovery
-- ✅ **Actively maintained** - part of the ROUP project
-
-## Quick Start
+## Quick start
 
 ```bash
-# Clone and build
-git clone https://github.com/your-org/roup.git
-cd roup/compat/accparser
-./build.sh
-
-# Run tests
-cd build
-LD_LIBRARY_PATH=. ./accparser_example
+./build.sh            # configure, build, and run the compat tests
 ```
+
+The script initialises the submodule, builds ROUP in release mode, compiles `libaccparser.so`, and executes the bundled tests.
 
 ## Requirements
 
-- **Rust** toolchain (cargo)
-- **CMake** 3.10+
-- **C++ compiler** (g++ or clang++)
-- **Git** (for submodules)
+- Rust toolchain (for building ROUP)
+- CMake 3.10+
+- C++ compiler (g++ or clang++)
+- Git for submodules
 
-**NO antlr4 required!**
+No ANTLR dependency is required.
 
-## Usage
-
-### Option 1: System-wide installation
+## Manual build
 
 ```bash
-cd compat/accparser/build
-sudo make install
-sudo ldconfig
+git submodule update --init --recursive
+cd ../.. && cargo build --release && cd compat/accparser
+mkdir -p build && cd build
+cmake ..
+make
+ctest --output-on-failure
 ```
 
-Then use in your project:
+Link `build/libaccparser.so` (or the corresponding static library) into existing applications. Header files live under `compat/accparser/accparser/src`.
 
-```cpp
-#include <OpenACCIR.h>
+## Feature parity
 
-OpenACCDirective* dir = parseOpenACC("acc parallel num_gangs(4)", nullptr);
-std::cout << dir->toString() << std::endl;
-delete dir;
-```
-
-Compile:
-```bash
-g++ myapp.cpp -laccparser -o myapp
-```
-
-### Option 2: Local linking
-
-```bash
-g++ myapp.cpp -I/path/to/roup/compat/accparser/accparser/src \
-    -L/path/to/roup/compat/accparser/build -laccparser -o myapp
-```
-
-## Architecture
-
-```
-Your Application
-       ↓
-parseOpenACC() entry point
-       ↓
-compat_impl.cpp (bridge layer)
-       ↓
-ROUP C API (acc_parse, etc.)
-       ↓
-ROUP Rust parser (fast!)
-       ↓
-accparser IR (OpenACCDirective, OpenACCClause)
-```
-
-**What's included:**
-- ROUP parser (replaces ANTLR-generated code)
-- accparser IR files (OpenACCIR.cpp, OpenACCIRToString.cpp)
-- Bridge layer (compat_impl.cpp)
-
-**What's excluded:**
-- ANTLR grammar files (.g4)
-- ANTLR-based AST constructor
-- antlr4 runtime dependency
-
-## Supported Features
-
-### Directives (17+)
-- Compute: `parallel`, `kernels`, `serial`, `loop`
-- Data: `data`, `enter data`, `exit data`, `host_data`
-- Synchronization: `wait`, `atomic`
-- Other: `declare`, `routine`, `init`, `shutdown`, `set`, `update`, `end`
-
-### Clauses (45+)
-- Compute: `num_gangs`, `num_workers`, `vector_length`, `async`, `wait`
-- Data: `copy`, `copyin`, `copyout`, `create`, `delete`, `present`
-- Loop: `gang`, `worker`, `vector`, `seq`, `independent`, `collapse`, `tile`
-- Other: `private`, `firstprivate`, `reduction`, `if`, `default`
-- Aliases: `pcopy`, `present_or_copy`, `pcopyin`, `present_or_copyin`, `pcopyout`,
-  `present_or_copyout`, `pcreate`, `present_or_create`, `dtype`
-
-See `src/roup_constants.h` for complete list.
-
-OpenACC support details and spec cross references live in
-[`docs/OPENACC_SUPPORT.md`](../../docs/OPENACC_SUPPORT.md).
+- Covers the same directive and clause surface as the upstream accparser while using ROUP's keyword tables.【F:docs/OPENACC_SUPPORT.md†L1-L53】
+- Preserves alias spellings when round-tripping directives through `OpenACCIR::toString`.【F:compat/accparser/tests/comprehensive_test.cpp†L1-L320】
+- Shares numeric identifiers with the C API so aliases and canonical names compare identically.【F:tests/openacc_c_api.rs†L9-L76】
 
 ## Testing
 
+The compatibility tests mirror the main suite:
+
 ```bash
 cd compat/accparser/build
-
-# Basic test
 LD_LIBRARY_PATH=. ./accparser_example
-
-# Comprehensive test suite (35+ tests)
 LD_LIBRARY_PATH=. ./comprehensive_test
-
-# Run all CMake tests
 ctest
 ```
 
-## Troubleshooting
-
-### Build fails: "accparser submodule not initialized"
-```bash
-git submodule update --init --recursive
-```
-
-### Build fails: "ROUP library not found"
-```bash
-cd ../..  # Go to ROUP root
-cargo build --release
-```
-
-### Test fails: "error while loading shared libraries"
-```bash
-cd compat/accparser/build
-LD_LIBRARY_PATH=. ./accparser_example
-```
-
-## Migration from accparser
-
-**No code changes needed!** This is a drop-in replacement.
-
-If you have existing code using accparser:
-
-```cpp
-// This code works unchanged
-#include <OpenACCIR.h>
-OpenACCDirective* dir = parseOpenACC("acc parallel", nullptr);
-// ... use dir ...
-delete dir;
-```
-
-Just recompile with `-laccparser` linking to our `libaccparser.so`.
-
-## Performance
-
-ROUP's hand-written parser is **2-5x faster** than ANTLR-generated parsers for typical OpenACC pragmas.
-
-## License
-
-Copyright (c) 2025 ROUP Project
-SPDX-License-Identifier: BSD-3-Clause
-
-## Contributing
-
-This is part of the ROUP project. See main ROUP repository for contribution guidelines.
-
 ## Support
 
-- Issues: https://github.com/your-org/roup/issues
-- Documentation: https://docs.roup-project.org
-- Original accparser: https://github.com/ouankou/accparser
+Report issues at <https://github.com/ouankou/roup/issues>. Documentation for the compatibility layer lives in the book chapter [`docs/book/src/accparser-compat.md`](../../docs/book/src/accparser-compat.md).

--- a/docs/OPENACC_SUPPORT.md
+++ b/docs/OPENACC_SUPPORT.md
@@ -1,63 +1,41 @@
 # OpenACC coverage
 
-ROUP implements the complete OpenACC 3.4 directive and clause surface. The
-canonical keyword catalogue lives in the mdBook chapter
-[`docs/book/src/openacc/openacc-3-4-directives-clauses.md`](book/src/openacc/openacc-3-4-directives-clauses.md),
-which cross-references every entry against the [OpenACC Application Programming
-Interface Version 3.4](https://www.openacc.org/sites/default/files/inline-files/OpenACC-3.4.pdf)
-specification.
+ROUP implements the full OpenACC 3.4 directive and clause surface. The mdBook chapter [`book/src/openacc/openacc-3-4-directives-clauses.md`](book/src/openacc/openacc-3-4-directives-clauses.md) catalogues every keyword with references back to the official [OpenACC 3.4 specification](https://www.openacc.org/sites/default/files/inline-files/OpenACC-3.4.pdf).
 
 ## Directive support matrix
 
-| Category            | Directives                                                                 |
-| ------------------- | -------------------------------------------------------------------------- |
-| Compute             | `parallel`, `serial`, `kernels`                                            |
-| Loop                | `loop`, `parallel loop`, `serial loop`, `kernels loop`                     |
-| Data                | `data`, `enter data`, `exit data`, `host_data` (space and underscore forms) |
-| Synchronisation     | `atomic`, `cache`, `wait`                                                  |
-| Declaration         | `declare`, `routine`                                                       |
-| Runtime             | `init`, `shutdown`, `set`, `update`                                        |
-| Terminators & other | `end <directive>` with full multi-word names                               |
+| Category            | Directives                                                                   |
+| ------------------- | ---------------------------------------------------------------------------- |
+| Compute             | `parallel`, `serial`, `kernels`                                              |
+| Loop                | `loop`, `parallel loop`, `serial loop`, `kernels loop`                       |
+| Data                | `data`, `enter data`, `exit data`, `host data` / `host_data`                 |
+| Synchronisation     | `atomic`, `cache`, `wait`                                                    |
+| Declaration         | `declare`, `routine`                                                         |
+| Runtime             | `init`, `shutdown`, `set`, `update`                                          |
+| Terminators & other | `end <directive>` with full multi-word spellings                             |
 
-All directive spellings (including synonyms such as `host data`, `host_data`,
-`enter data`, and `enter_data`) are registered in the parser and mirrored into
-the C API and the accparser compatibility shim. The new
-`tests/openacc_keyword_coverage.rs` integration suite exercises every directive
-string and validates round-tripping through `Directive::to_pragma_string`.【F:tests/openacc_keyword_coverage.rs†L6-L71】【F:tests/openacc_keyword_coverage.rs†L101-L164】
+All directive spellings, including synonyms such as `host data`/`host_data` and `enter data`/`enter_data`, are registered in the parser and propagated through the Rust and C APIs. The integration suite in `tests/openacc_keyword_coverage.rs` exercises every directive string and validates round-tripping through `Directive::to_pragma_string`.【F:tests/openacc_keyword_coverage.rs†L6-L164】
 
 ## Clause coverage
 
-| Category                | Clauses and aliases                                                                                                       |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| Parallelism & control   | `async`, `wait`, `num_gangs`, `num_workers`, `vector_length`, `gang`, `worker`, `vector`, `seq`, `independent`, `auto`    |
-| Conditionals            | `if`, `if_present`, `self`, `default`, `default_async`                                                                    |
-| Data movement           | `copy`, `copyin`, `copyout`, `create`, `delete`, `present`, `no_create`, `device`, `deviceptr`, `device_resident`, `host` |
-| Pointer management      | `attach`, `detach`, `link`, `use_device`                                                                                  |
-| Sharing & reductions    | `private`, `firstprivate`, `reduction`                                                                                    |
-| Loop transforms         | `collapse`, `tile`                                                                                                        |
-| Device specialisation   | `device_type`, alias `dtype`                                                                                              |
-| Atomic modifiers        | `read`, `write`, `capture`, `update`                                                                                      |
-| Synonym aliases         | `pcopy`, `present_or_copy`, `pcopyin`, `present_or_copyin`, `pcopyout`, `present_or_copyout`, `pcreate`, `present_or_create` |
+| Category              | Clauses and aliases                                                                                                        |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Parallelism & control | `async`, `wait`, `num_gangs`, `num_workers`, `vector_length`, `gang`, `worker`, `vector`, `seq`, `independent`, `auto`      |
+| Conditionals          | `if`, `if_present`, `self`, `default`, `default_async`                                                                     |
+| Data movement         | `copy`, `copyin`, `copyout`, `create`, `delete`, `present`, `no_create`, `device`, `deviceptr`, `device_resident`, `host`   |
+| Pointer management    | `attach`, `detach`, `link`, `use_device`                                                                                   |
+| Sharing & reductions  | `private`, `firstprivate`, `reduction`                                                                                     |
+| Loop transforms       | `collapse`, `tile`                                                                                                         |
+| Device specialisation | `device_type`, alias `dtype`                                                                                               |
+| Atomic modifiers      | `read`, `write`, `capture`, `update`                                                                                       |
+| Synonym aliases       | `pcopy`, `present_or_copy`, `pcopyin`, `present_or_copyin`, `pcopyout`, `present_or_copyout`, `pcreate`, `present_or_create` |
 
-Clause registration keeps the original surface spelling. Alias spellings share
-the same numeric identifiers in the C API so existing code can treat them as
-synonyms while retaining the original source text. The parser-level coverage
-suite validates every clause and alias (including atomic update as a bare
-clause), and the C API tests assert that aliases collapse to the same integer
-kind IDs as their canonical forms.【F:tests/openacc_keyword_coverage.rs†L101-L164】【F:tests/openacc_c_api.rs†L9-L76】
+Alias spellings share numeric identifiers in the C API so existing code can treat them as synonyms while retaining the original source text. The parser-level coverage tests validate every clause and alias, and the C API tests assert that aliases collapse to the same integer IDs as their canonical forms.【F:tests/openacc_keyword_coverage.rs†L101-L164】【F:tests/openacc_c_api.rs†L9-L76】
 
 ## Compatibility layer parity
 
-The accparser bridge exercises the new coverage, ensuring the C++ drop-in
-replacement emits the same directive kinds and serialises aliases without
-normalisation. The extended `compat/accparser/tests/comprehensive_test.cpp`
-suite now exercises mixed alias usage, host-data spacing variants, dtype
-shorthands, and atomic update round-tripping through `OpenACCIR::toString`.【F:compat/accparser/tests/comprehensive_test.cpp†L1-L320】
+The accparser bridge (`compat/accparser/`) exercises the same keyword tables, ensuring the drop-in replacement emits identical directive kinds and preserves alias spellings. The extended `compat/accparser/tests/comprehensive_test.cpp` suite covers mixed alias usage, host-data spacing variants, dtype shorthands, and atomic update round-tripping through `OpenACCIR::toString`.【F:compat/accparser/tests/comprehensive_test.cpp†L1-L320】
 
 ## Regression protection
 
-The end-to-end round-trip and C API tests sit alongside the existing OpenACC
-round-trip checks, so any future change to the keyword registry or numeric
-mappings will fail CI before shipping. These tests complement the existing
-round-trip scenarios in `tests/openacc_roundtrip.rs` and cover cache
-directives, alias preservation, dtype handling, and atomic update parsing.【F:tests/openacc_roundtrip.rs†L1-L123】
+Keyword registration lives alongside round-trip tests in `tests/openacc_roundtrip.rs`, so any change to the registry or numeric mappings fails CI immediately. These tests cover cache directives, alias preservation, dtype handling, and atomic update parsing.【F:tests/openacc_roundtrip.rs†L1-L123】

--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -1,13 +1,18 @@
 # Documentation build notes
 
-The `docs/book` directory hosts the mdBook sources for https://roup.ouankou.com.
+The `docs/book` directory hosts the mdBook sources deployed to <https://roup.ouankou.com>.
 
-- Install mdBook with `cargo install mdbook`.
-- Run `mdbook serve` for a live preview or `mdbook build` to produce static
-  pages.
-- Copy `target/doc` into `docs/book/book/api/` after running `cargo doc --no-deps`
-  to bundle the Rust API reference alongside the book.
+## Local preview
 
-GitHub Actions (`docs.yml`) builds both outputs on `main` and publishes them to
-GitHub Pages. The `book.toml` configuration tracks the custom domain and other
-mdBook options.
+```bash
+cargo install mdbook
+mdbook serve docs/book --open
+```
+
+Use `mdbook build docs/book` for a static build. The generated HTML lives in `docs/book/book/`.
+
+## API docs
+
+Run `cargo doc --no-deps --all-features` to refresh the Rust API reference. Copy the output from `target/doc/` into `docs/book/book/api/` before publishing if you want the API reference bundled with the book.
+
+GitHub Actions builds both outputs on `main` via `docs.yml` and publishes them to GitHub Pages.


### PR DESCRIPTION
## Summary
- condense the top-level README and testing guide to remove redundant wording while keeping key workflows
- update OpenACC support docs and the accparser README for accurate links and clearer coverage notes
- refresh docs/book build instructions to focus on the current mdBook pipeline

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f66159423c832f97d89d16a5df76a9