### PR TITLE
docs: streamline top-level guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,44 @@
 # ROUP: Rust-based OpenMP Parser
 
-Rust-first parsing for OpenMP directives with C and C++ bindings.
+Rust-first parsing for OpenMP and OpenACC directives with optional C and C++
+bindings.
 
 [![Docs](https://img.shields.io/badge/docs-roup.ouankou.com-blue)](https://roup.ouankou.com)
 [![Status](https://img.shields.io/badge/status-experimental-orange)](https://github.com/ouankou/roup)
 
-> **Experimental:** APIs are still evolving. Expect breaking changes between releases.
+> **Experimental:** public APIs may change between releases.
+
+## Highlights
+
+- **Standards coverage:** OpenMP 3.0–6.0 plus the documented
+  [OpenACC 3.4 matrix](docs/OPENACC_SUPPORT.md).
+- **Multi-language APIs:** idiomatic Rust with C and C++17 bindings generated
+  from the same tables.
+- **Unsafe boundary kept tight:** the FFI layer owns the only unsafe code.
+- **Extensive validation:** 620+ automated tests including OpenMP_VV and
+  OpenACCV-V round trips.
+- **ompparser compatibility:** drop-in shim at [`compat/ompparser/`](compat/ompparser/).
 
 ## Quick start
 
-### Rust
+**Rust**
+
 ```toml
 [dependencies]
 roup = "0.5"
 ```
 
-### C or C++
+**C or C++**
+
 ```bash
 cargo build --release
 # Link against target/release/libroup.{a,so,dylib}
 ```
 
-Need platform-specific notes? See the [building guide](https://roup.ouankou.com/building.html).
+Platform notes and additional options live in the
+[building guide](https://roup.ouankou.com/building.html).
 
-## Why ROUP?
-
-- **OpenMP 3.0–6.0 coverage**: directives, clauses, and combined forms.
-- **OpenACC 3.4 coverage**: full directive and clause matrix documented in
-  [`docs/OPENACC_SUPPORT.md`](docs/OPENACC_SUPPORT.md).
-- **Multi-language APIs**: idiomatic Rust plus C and C++17 bindings.
-- **Tight unsafe boundary**: the FFI layer is the only unsafe code.
-- **Thorough testing**: 620+ automated tests across languages.
-- **ompparser compatibility**: optional shim for existing consumers.
-
-## Documentation
-
-All guides live at [roup.ouankou.com](https://roup.ouankou.com):
-
-- [Getting started](https://roup.ouankou.com/getting-started.html)
-- [Rust tutorial](https://roup.ouankou.com/rust-tutorial.html)
-- [C tutorial](https://roup.ouankou.com/c-tutorial.html)
-- [C++ tutorial](https://roup.ouankou.com/cpp-tutorial.html)
-- [API reference](https://roup.ouankou.com/api-reference.html)
-- [Architecture](https://roup.ouankou.com/architecture.html)
-- [OpenACC support matrix](docs/OPENACC_SUPPORT.md)
-
-## Minimal example
+## Example
 
 ```rust
 use roup::parser::parse;
@@ -57,7 +50,7 @@ fn main() {
 }
 ```
 
-Additional C and C++ samples are available in [`examples/`](examples/).
+More Rust, C, and C++ samples live in [`examples/`](examples/).
 
 ## Build and test
 
@@ -66,33 +59,18 @@ cargo build --release
 cargo test
 ```
 
-The book can be rebuilt with `cargo doc --no-deps`.
+Build the mdBook with `cargo doc --no-deps`.
 
 ## ompparser compatibility
 
-The optional layer in [`compat/ompparser/`](compat/ompparser/) exposes the same headers as the original ompparser project. Build
- it with `./compat/ompparser/build.sh` or follow the manual steps in
- [the compatibility guide](docs/book/src/ompparser-compat.md).
+[`compat/ompparser/`](compat/ompparser/) ships headers that mirror the original
+ompparser project. Build it with `./compat/ompparser/build.sh` or follow the
+manual steps in [the compatibility guide](docs/book/src/ompparser-compat.md).
 
 ## Contributing
 
-Contributions are welcome. Review the [contributing guide](https://roup.ouankou.com/contributing.html) for coding standards, te
-st expectations, and the pull-request workflow.
-
-## Learning Resources
-
-ROUP demonstrates Rust concepts from basics to advanced:
-
-- **Basics:** Structs, enums, pattern matching, ownership
-- **Intermediate:** Traits, generics, error handling, modules
-- **Advanced:** Parser combinators (nom), FFI, unsafe boundaries
-
-**For learners:**
-- Read the [Architecture Guide](https://roup.ouankou.com/architecture.html)
-- Study the [examples](examples/) directory
-- Check the commit history for evolution
-
----
+Read the [contributing guide](https://roup.ouankou.com/contributing.html) for
+coding standards, tests, and the pull-request workflow.
 
 ## License
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,70 +2,29 @@
 
 ## 0.5.0 (2025-10-18)
 
-### Major Features
+### Highlights
 
-**Translation API** - C/C++ ↔ Fortran Directive Translation
-- Added comprehensive translation infrastructure for converting OpenMP directives between C/C++ and Fortran
-- Rust API: `translate::translate()` with automatic format detection
-- C API: `roup_translate_c_to_fortran()` and `roup_translate_fortran_to_c()` with explicit format control
-- Full support for both free-form and fixed-form Fortran (with proper column-based sentinel positioning)
-- Handles language-specific syntax differences (DO vs FOR, array section parentheses vs brackets)
-- See [Translation API documentation](https://roup.ouankou.com/api-reference.html#translation-api) for details
+- **Translation API:** bidirectional OpenMP directive translation between C/C++
+  and Fortran with automatic sentinel handling and C bindings.
+- **OpenMP_VV validation:** 3767/3767 pragmas round-trip successfully; scripts
+  and binaries ship in-tree.
+- **Fortran sentinels:** accepts both traditional and short forms in free- and
+  fixed-form code with new tests covering each variant.
+- **Parser polish:** custom parsers for directives with bespoke syntax, optional
+  arguments for `nowait`/`safesync`, and support for the previously missing
+  `end assumes`, `master taskloop`, and `master taskloop simd` directives.
+- **Testing:** suite now exceeds 620 cases including OpenMP_VV, translation
+  round-trips, and expanded Fortran coverage. CI runs MSRV (1.85) plus stable
+  across Ubuntu, Windows, and macOS.
+- **Documentation:** translation guide, OpenMP_VV walkthrough, and architecture
+  chapters updated to match the release.
+- **Internal:** `CUSTOM_PARSER_DIRECTIVES` constant consolidates bespoke rules,
+  `parse_parenthesized_content()` reuses lexer helpers, and the build/test
+  scripts surface clearer diagnostics.
 
-**OpenMP_VV Validation** - 100% Round-Trip Pass Rate
-- Achieved **100% success rate** (3767/3767 pragmas) on the official [OpenMP Validation & Verification](https://github.com/OpenMP-Validation-and-Verification/OpenMP_VV) test suite
-- Validates ROUP against real-world OpenMP code from the comprehensive OpenMP_VV repository
-- Automated round-trip testing: parse → unparse → compare with clang-format normalization
-- Added `test_openmp_vv.sh` script and `roup_roundtrip` binary for validation
-- Enhanced parser with 10 custom directive parsers for non-standard syntax patterns
-- Updated test infrastructure to require 100% pass rate in CI
+### Compatibility
 
-**Enhanced Fortran Support**
-- Short-form Fortran sentinels: `!$` (free-form) and `      !$` (fixed-form, must start in column 7)
-  - Note: In fixed-form Fortran, the sentinel must begin in column 7 (i.e., six leading spaces before `!$`)
-- Comprehensive sentinel variation tests covering all valid OpenMP Fortran comment formats
-- Full support for both traditional (`!$OMP`/`      !$OMP`) and short (`!$`/`      !$`) forms
-
-### Parser Improvements
-
-- **Custom directive parsers** for 10 directives with special syntax:
-  - `allocate(list)`, `threadprivate(list)`, `declare target(list)`
-  - `declare mapper(id)`, `declare variant(func)`, `depobj(obj)`
-  - `scan exclusive/inclusive(list)`, `cancel construct-type`
-  - `groupprivate(list)`, `target_data` (underscore variant)
-- **Flexible clause rules**: `nowait` and `safesync` now support optional arguments
-- **Comment handling**: Proper support for comments between directive names and parenthesized content
-- **Missing directives added**: `end assumes`, `master taskloop`, `master taskloop simd`
-
-### Testing & Validation
-
-- Test suite now at **620 automated tests** (up from 600+)
-- New test categories:
-  - OpenMP_VV round-trip validation (3767 real-world pragmas)
-  - Translation round-trip tests (C/C++ ↔ Fortran)
-  - Fortran sentinel variation tests
-  - Custom parser integration tests
-- Updated MSRV testing approach: 1.85 (MSRV) + stable only
-- Enhanced CI matrix: 6 jobs (2 Rust versions × 3 OSes)
-
-### Documentation
-
-- Comprehensive translation API documentation with examples
-- Detailed OpenMP_VV validation documentation in `TESTING.md`
-- Updated architecture documentation
-- Consolidated and streamlined guides
-- All statistics and numbers verified for accuracy
-
-### Internal Improvements
-
-- Constant `CUSTOM_PARSER_DIRECTIVES` for maintainability
-- Simplified `parse_parenthesized_content()` using lexer utilities
-- Platform-specific installation instructions in test scripts
-- Enhanced error messages and debugging support
-
-### Breaking Changes
-
-**None** - All changes are backward compatible for Rust, C, and C++ callers.
+No breaking changes for Rust, C, or C++ callers.
 
 ## 0.4.0 (2025-10-11)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,611 +1,88 @@
 # Testing Guide
 
-This document describes the testing infrastructure and how to ensure your changes work across all supported Rust versions.
+ROUP ships two shell scripts that mirror the CI workflow. Run them before
+opening a pull request.
 
-## Quick Start
+## Essential commands
 
 ```bash
-# Run all local tests (current Rust version)
+# Full suite on your current toolchain
 ./test.sh
 
-# Test MSRV and stable (recommended before PR)
+# Minimum supported Rust version (MSRV) + stable
 ./test_rust_versions.sh
 
-# Test specific versions
+# Optional: specify exact toolchains
 ./test_rust_versions.sh 1.85 stable
 ```
 
-## Rust Version Support Policy
+## Rust toolchain policy
 
-### MSRV + Stable Approach
+- **MSRV:** 1.85.0 (first release with edition 2024 support used by the
+  documentation toolchain). The version is recorded in `Cargo.toml` and the CI
+  workflow.
+- **Stable:** latest stable release. Clippy changes between toolchains, so we
+  test MSRV and stable to catch differences early.
+- Update the value only when a new language feature or dependency requires it.
+  When bumping MSRV, touch `Cargo.toml`, `.github/workflows/ci.yml`, and this
+  document.
 
-ROUP follows the standard Rust ecosystem practice of testing **MSRV (Minimum Supported Rust Version) + stable**:
+## Script reference
 
-- **MSRV: 1.85.0**
-  - Minimum version supporting edition2024 (required for mdBook dependencies)
-  - Released February 2025
-  - Set in `Cargo.toml` as `rust-version = "1.85.0"`
-  - Only bumped when new language features or tooling requirements needed
+### `test.sh`
 
-- **Stable: Latest stable release**
-  - Ensures compatibility with current Rust ecosystem
-  - Catches new lints and API changes early
+Runs the comprehensive local suite on the active toolchain:
 
-**Why This Approach?**
+- Formatting, Clippy (`-D warnings`), debug and release builds
+- Unit, integration, and doctests
+- Example builds (Rust, C, C++)
+- mdBook build
+- ompparser compatibility checks
+- OpenMP_VV and OpenACCV-V round-trip validation (skips when prerequisites are
+  unavailable)
 
-- ✅ **Industry standard**: Most Rust crates use MSRV + stable
-- ✅ **edition2024 support**: 1.85 is first stable version with edition2024
-- ✅ **Lower maintenance**: Only 2 versions to track instead of 6
-- ✅ **Clear compatibility promise**: Users know minimum version required
-- ✅ **Fewer CI minutes**: 2×3 = 6 jobs instead of 6×3 = 18
+### `test_rust_versions.sh`
 
-**CI Matrix:**
-- **Rust versions:** 1.85 (MSRV), stable (2 versions)
-- **Operating systems:** Ubuntu 24.04, Windows 2025, macOS 15 (3 OSes)
-- **Total combinations:** 6 jobs
+Validates critical checks across multiple toolchains:
 
-### When to Bump MSRV
+- Reads the toolchain list from `.github/workflows/ci.yml` so local testing stays
+  aligned with CI
+- Installs the requested toolchains via `rustup`
+- Runs formatting, Clippy, `cargo build`, and `cargo test`
+- Restores your original toolchain after finishing
 
-MSRV should only be bumped when:
-- ✅ You need a new language feature not available in current MSRV
-- ✅ A critical dependency requires a newer Rust version
-- ✅ Ubuntu LTS updates to a newer default Rust version
+Use this script before a pull request or whenever CI reports a
+version-specific failure.
 
-MSRV should NOT be bumped for:
-- ❌ Clippy lint changes (fix the code instead)
-- ❌ "Nice to have" features
-- ❌ Following the latest Rust version
+## Continuous integration
 
-**When bumping MSRV:**
-1. Update `Cargo.toml`: `rust-version = "1.XX.0"`
-2. Update `.github/workflows/ci.yml`: `version: ["1.XX", "stable"]`
-3. Update this documentation
-4. Document the reason in the commit message
+GitHub Actions runs six jobs:
 
-## Rust Version Configuration
+- **Toolchains:** 1.85 (MSRV) and stable
+- **Operating systems:** Ubuntu 24.04, Windows, and macOS
 
-### CI Config - Single Source of Truth
+The build job performs the same checks as `test.sh`; the docs job rebuilds the
+mdBook and API documentation with warnings denied.
 
-The **CI workflow file** (`.github/workflows/ci.yml`) is the **single source of truth** for Rust versions. The `test_rust_versions.sh` script **automatically parses** the CI config to extract the version list, ensuring local testing always matches CI exactly.
+## Validation suites
 
-**How it works:**
+The round-trip scripts live at the repository root:
 
-```bash
-# test_rust_versions.sh automatically reads from CI config
-$ ./test_rust_versions.sh
+- `test_openmp_vv.sh` validates every pragma in the
+  [OpenMP Validation & Verification](https://github.com/OpenMP-Validation-and-Verification/OpenMP_VV)
+  repository.
+- `test_openacc_vv.sh` performs the equivalent pass for the
+  [OpenACCV-V](https://github.com/OpenACCUserGroup/OpenACCV-V) suite across both
+  C/C++ and Fortran input.
 
-# Internally, it parses:
-# .github/workflows/ci.yml
-#   version: ["1.85", "stable"]
-#
-# And tests those exact versions locally
-```
-
-**When updating MSRV:**
-
-1. Update **TWO places** (kept in sync):
-   ```yaml
-   # .github/workflows/ci.yml
-   version: ["1.85", "stable"]
-   ```
-
-   ```toml
-   # Cargo.toml
-   rust-version = "1.85.0"
-   ```
-
-2. Run `./test_rust_versions.sh` - automatically picks up the new version:
-   ```bash
-   $ ./test_rust_versions.sh
-   Testing against Rust versions: 1.85 stable
-   ```
-
-3. Update this TESTING.md documentation.
-
-## Test Scripts
-
-### test.sh - Comprehensive Local Testing
-
-Runs all 22 test categories on your current Rust version:
-
-1. Code formatting (`cargo fmt --check`)
-2. Debug build
-3. Release build
-4. Unit tests
-5. Integration tests
-6. Doc tests
-7. All tests together
-8. Examples build
-9. API documentation
-10. ompparser compatibility
-11. mdBook build
-12. mdBook tests
-13. C examples (build + run)
-14. C++ examples (build + run)
-15. Fortran examples
-16. Header verification
-17. Warning check (zero tolerance)
-18. Clippy lints (zero tolerance)
-19. OpenMP_VV round-trip validation (100% required)
-20. OpenACCV-V round-trip validation (100% required)
-21. All features test
-22. Benchmarks
-
-**Zero-Tolerance Policy:**
-- Any warning = FAIL
-- Missing required files = FAIL
-- All tests are MANDATORY
-
-### test_rust_versions.sh - Multi-Version Testing
-
-Tests your code against multiple Rust versions to catch version-specific issues **before** CI fails.
-
-**Why This Matters:**
-
-Clippy lints evolve across Rust versions. A lint that passes on stable might fail on MSRV (or vice versa). Examples:
-- **Rust 1.85+**: `clippy::needless_lifetimes` became stricter
-- **Rust 1.88+**: `clippy::uninlined_format_args` became stricter
-- **Your local version**: Might be different from CI matrix
-
-**How It Works:**
-
-1. Automatically parses CI config to get version list
-2. Uses `rustup` to install/switch between Rust versions
-3. Runs critical checks on each version:
-   - Format check
-   - Clippy with `-D warnings`
-   - Build
-   - Tests
-4. Reports which versions pass/fail
-5. Restores your original Rust version
-
-**Usage:**
-
-```bash
-# Test MSRV + stable (mirrors CI matrix)
-./test_rust_versions.sh
-
-# Test specific versions
-./test_rust_versions.sh 1.85 stable
-
-# Test with custom versions (for debugging)
-./test_rust_versions.sh 1.85 1.86 1.87 stable
-```
-
-**When to Use:**
-
-- ✅ Before creating a PR
-- ✅ After fixing clippy warnings
-- ✅ After making lifetime changes
-- ✅ When updating dependencies
-- ✅ When CI fails on a specific version
-
-## CI Testing
-
-The GitHub Actions CI runs a focused matrix:
-
-**Matrix Dimensions:**
-- **Rust versions:** 1.85 (MSRV), stable (2 versions)
-- **Operating systems:** Ubuntu 24.04, Windows 2025, macOS 15 (3 OSes)
-- **Total combinations:** 6 jobs
-
-**CI Workflow:**
-
-1. **Build Job** (6 parallel jobs):
-   - Format check
-   - Clippy lints (`-D warnings`)
-   - Debug build
-   - Release build
-   - All tests
-   - All features test
-   - Benchmark validation
-   - C examples (Linux only)
-   - C++ examples (Linux only)
-   - Fortran examples (Linux only)
-   - Header verification (Linux only)
-   - ompparser compat (Linux only)
-
-2. **Docs Job** (runs after build):
-   - mdBook tests
-   - mdBook build
-   - API docs (`RUSTDOCFLAGS: "-D warnings"`)
-   - Examples build
-   - Deploy to GitHub Pages (main branch only)
-
-**Why Multiple OSes?**
-
-- Different OS = Different default compilers, different file paths, different behaviors
-- We want to ensure the code works **everywhere**
-
-## Catching Version-Specific Issues
-
-### The Problem
-
-Clippy lints change between Rust versions:
-- New lints are added
-- Existing lints become stricter
-- Some lints are deprecated
-
-**Real Examples:**
-- The `needless_lifetimes` lint was introduced/strictened in Rust 1.85
-- The `uninlined_format_args` lint became stricter in Rust 1.88
-
-### The Solution
-
-**Local Testing:**
-```bash
-# Before pushing, test against the CI version range
-./test_rust_versions.sh
-
-# If any version fails, fix the issue
-# The script will show you the exact error
-```
-
-**Understanding Failures:**
-
-When `test_rust_versions.sh` reports a failure:
-
-```
-✗ Rust 1.85: FAILED
-Clippy errors for Rust 1.85:
-error: the following explicit lifetimes could be elided: 'a
-  --> src/lexer.rs:255:36
-```
-
-This tells you:
-1. Which version failed (1.85)
-2. What failed (clippy)
-3. The exact error and location
-
-**Fixing Version-Specific Issues:**
-
-1. Check the clippy documentation for the lint
-2. Apply the suggested fix (often `cargo clippy --fix` works)
-3. Re-run `./test_rust_versions.sh` to verify
-4. Run `./test.sh` to ensure all other tests still pass
-
-## Best Practices
-
-### Before Committing
-
-```bash
-# 1. Format your code
-cargo fmt
-
-# 2. Run full test suite
-./test.sh
-
-# 3. Test against MSRV and stable
-./test_rust_versions.sh
-```
-
-### Before Creating a PR
-
-```bash
-# Test the full version matrix (mirrors CI)
-./test_rust_versions.sh
-```
-
-### When CI Fails
-
-1. **Check which version failed** in the CI logs
-2. **Install that version locally:**
-   ```bash
-   rustup install 1.85
-   rustup override set 1.85
-   ```
-3. **Run clippy to see the error:**
-   ```bash
-   cargo clippy --all-targets -- -D warnings
-   ```
-4. **Fix the issue** (try `cargo clippy --fix --allow-dirty` first)
-5. **Verify with test_rust_versions.sh:**
-   ```bash
-   ./test_rust_versions.sh 1.85
-   ```
-6. **Restore your normal version:**
-   ```bash
-   rustup override unset
-   ```
-
-## Understanding Test Output
-
-### test.sh Output
-
-```
-========================================
-  ROUP Comprehensive Test Suite
-========================================
-
-Environment:
-rustc 1.90.0 (1159e78c4 2025-09-14)
-clippy 0.1.90 (1159e78c47 2025-09-14)
-
-=== 1. Formatting Check ===
-Running cargo fmt --check... ✓ PASS
-...
-========================================
-  ALL 22 TEST CATEGORIES PASSED
-========================================
-```
-
-The "Environment" section shows which Rust/clippy version you're testing with. This helps identify if issues are version-related.
-
-### test_rust_versions.sh Output
-
-```
-========================================
-  Rust Version Compatibility Test
-========================================
-
-Testing against Rust versions: 1.85 stable
-
-========================================
-Testing Rust 1.85
-========================================
-  rustc: rustc 1.85.0 (a28077b28 2025-02-20)
-  clippy: clippy 0.1.85
-
-Running critical checks:
-  1. Format check... ✓
-  2. Clippy lints... ✗ FAILED
-
-Clippy errors for Rust 1.82:
-error: the following explicit lifetimes could be elided: 'a
-...
-
-========================================
-  Summary
-========================================
-Tested versions: 2
-Passed: 1
-Failed: 1
-
-Failed versions:
-  - 1.82 (clippy)
-```
-
-This clearly shows which version failed and why.
-
-## OpenMP_VV Round-Trip Validation
-
-ROUP can validate itself against the [OpenMP Validation & Verification (OpenMP_VV)](https://github.com/OpenMP-Validation-and-Verification/OpenMP_VV) test suite by round-tripping every pragma through the parser.
-
-### How It Works
-
-The validation process:
-
-1. **Clone OpenMP_VV** (automatically on first run to `target/openmp_vv`)
-2. **Find all C/C++ test files** in the `tests/` directory
-3. **Preprocess with clang** to expand macros and includes
-4. **Extract OpenMP pragmas** (lines starting with `#pragma omp`)
-5. **Round-trip each pragma**:
-   - Normalize original with `clang-format`
-   - Parse with ROUP → unparse to string
-   - Normalize round-tripped version with `clang-format`
-   - Compare with `diff`
-6. **Report statistics**: total pragmas, pass/fail counts, success rate
-
-### Running the Test
-
-```bash
-# Run OpenMP_VV validation (auto-clones repository if needed)
-./test_openmp_vv.sh
-
-# Or as part of the full test suite
-./test.sh  # Includes OpenMP_VV as section 18
-```
-
-### Using Existing Repository
-
-If you already have OpenMP_VV cloned elsewhere:
-
-```bash
-# Point to existing clone
-OPENMP_VV_PATH=/path/to/OpenMP_VV ./test_openmp_vv.sh
-
-# Use specific clang version
-CLANG=clang-15 CLANG_FORMAT=clang-format-15 ./test_openmp_vv.sh
-```
-
-### Example Output
-
-```
-=========================================
-  OpenMP_VV Round-Trip Validation
-=========================================
-
-Checking for required tools...
-✓ All required tools found
-
-Using existing OpenMP_VV at target/openmp_vv
-
-Building roup_roundtrip binary...
-✓ Binary built
-
-Finding C/C++ test files in target/openmp_vv/tests...
-Found 247 C/C++ files
-
-Processing files...
-
-=========================================
-  Results
-=========================================
-
-Files processed:        247
-Files with pragmas:     183
-Total pragmas:          1247
-
-Passed:                1189
-Failed:                58
-  Parse errors:         12
-  Mismatches:           46
-
-Success rate:           95.3%
-```
-
-### Requirements
-
-- **clang** - For preprocessing (macros, includes)
-- **clang-format** - For pragma normalization
-- **cargo** - To build the `roup_roundtrip` binary
-- **git** - To clone OpenMP_VV (if not already present)
-
-The test gracefully skips if clang/clang-format are not available.
-
-### Implementation Details
-
-The validation uses two simple components:
-
-1. **`roup_roundtrip` binary** (~30 lines of Rust):
-   - Reads one pragma from stdin
-   - Parses and unparses it
-   - Prints to stdout
-   - Exits with code 1 on parse error
-
-2. **`test_openmp_vv.sh` script** (~200 lines of bash):
-   - Orchestrates the entire workflow
-   - Uses standard Unix tools (find, grep, diff)
-   - Tracks statistics and formats output
-
-This approach is simpler and more maintainable than complex Rust-only solutions.
-
-## OpenACCV-V Round-Trip Validation
-
-ROUP can validate itself against the [OpenACCV-V](https://github.com/OpenACCUserGroup/OpenACCV-V) test suite by round-tripping every directive through the parser. The flow mirrors the OpenMP validation but supports both C/C++ `#pragma acc` and Fortran `!$acc` forms.
-
-### How It Works
-
-The validation process:
-
-1. **Clone OpenACCV-V** (automatically on first run to `target/openacc_vv`)
-2. **Find all C/C++/Fortran test files** in the `Tests/` directory
-3. **Extract OpenACC directives** (lines with `#pragma acc`, `!$acc`, `c$acc`, `*$acc`)
-4. **Round-trip each directive**:
-   - Normalize original with bash whitespace collapsing
-   - Parse with ROUP → unparse to string
-   - Normalize round-tripped version with bash
-   - Compare with string equality
-5. **Report statistics**: total directives, pass/fail counts, success rate
-
-### Running the Test
-
-```bash
-# Run OpenACCV-V validation (auto-clones repository if needed)
-./test_openacc_vv.sh
-
-# Or as part of the full test suite
-./test.sh  # Includes OpenACCV-V as section 20
-```
-
-### Using Existing Repository
-
-If you already have OpenACCV-V cloned elsewhere:
-
-```bash
-# Point to existing clone
-OPENACC_VV_PATH=/path/to/OpenACCV-V ./test_openacc_vv.sh
-```
-
-### Example Output
-
-```
-=========================================
-  OpenACCV-V Round-Trip Validation
-=========================================
-
-Checking for required tools...
-✓ All required tools found
-
-Using existing OpenACCV-V at target/openacc_vv
-
-Building roup_roundtrip binary...
-✓ Binary built
-
-Running OpenACCV-V validator...
-=========================================
-  OpenACCV-V Round-Trip Validation
-=========================================
-
-Files processed:        1336
-Files with pragmas:     1304
-Total pragmas:          9417
-
-Passed:                 9417
-Failed:                 0
-  Parse errors:         0
-  Mismatches:           0
-
-Success rate:           100.0%
-```
-
-### Requirements
-
-- **cargo** - To build the `roup_roundtrip` binary
-- **git** - To clone OpenACCV-V (if not already present)
-
-The test gracefully skips if requirements are not met.
-
-### Implementation Details
-
-The validation uses two simple components:
-
-1. **`roup_roundtrip --acc` binary** (~120 lines of Rust):
-   - Reads one directive from stdin
-   - Detects language (C/C++ or Fortran)
-   - Parses and unparses it
-   - Prints to stdout
-   - Exits with code 1 on parse error
-
-2. **`test_openacc_vv.sh` script** (~230 lines of bash):
-   - Orchestrates the entire workflow
-   - Uses standard Unix tools (find, grep, sed)
-   - Tracks statistics and formats output
-
-This approach is simpler and more maintainable than complex Rust-only solutions.
+Both scripts clone their upstream repositories into `target/` on first run and
+skip gracefully if required tools such as `clang` or `clang-format` are missing.
 
 ## FAQ
 
-**Q: Why MSRV + stable instead of testing many versions?**
-A: This is the standard Rust ecosystem practice. It's lower maintenance, clearer to users, and sufficient for catching issues. If it works on MSRV and stable, it almost always works on versions in between.
-
-**Q: What is our MSRV and why?**
-A: 1.85.0 - it's the first stable Rust version supporting edition2024, which is required by mdBook dependencies (specifically the `ignore` crate 0.4.24+).
-
-**Q: When will MSRV be bumped?**
-A: Only when we need new language features or Ubuntu LTS updates its default. Not for clippy lints or "nice to have" features.
-
-**Q: Which versions should I test locally?**
-A: Run `./test_rust_versions.sh` which automatically tests MSRV (1.85) + stable.
-
-**Q: Do I need to test all 6 CI jobs locally?**
-A: No! `test_rust_versions.sh` tests multiple Rust versions but only on your OS. That's usually sufficient since most issues are version-related, not OS-related.
-
-**Q: What if I don't have rustup?**
-A: Install it from https://rustup.rs/ - it's the standard Rust toolchain manager and required for managing multiple versions.
-
-**Q: Can I skip version testing?**
-A: You can, but CI will catch the issue later. Testing locally saves you a round-trip to CI (faster feedback).
-
-**Q: What's the difference between test.sh and test_rust_versions.sh?**
-- `test.sh`: Comprehensive (22 categories) on YOUR current Rust version
-- `test_rust_versions.sh`: Critical checks (4 checks) on MULTIPLE Rust versions (MSRV + stable)
-
-Use both for maximum confidence!
-
-**Q: Can I test intermediate versions like 1.82 or 1.85?**
-A: Yes! While CI only tests MSRV + stable, you can test any version locally:
-```bash
-./test_rust_versions.sh 1.85 1.86 1.87 stable
-```
-This is useful when debugging version-specific issues.
-
-## Continuous Improvement
-
-This testing infrastructure is designed to catch issues early. If you encounter a new class of version-specific issue:
-
-1. Document it in this file
-2. Consider adding a specific check to test_rust_versions.sh
-3. Share the knowledge in PR comments
-
-Together we keep the code quality high! 🚀
+- **Why MSRV + stable?** It keeps maintenance manageable while covering the two
+  toolchains most likely to expose Clippy or compiler differences.
+- **Do I need rustup?** Yes. The scripts use `rustup` to install and select the
+  toolchains they need.
+- **Can I test other versions?** Pass additional toolchains to
+  `test_rust_versions.sh`, for example `./test_rust_versions.sh 1.85 1.86 stable`.


### PR DESCRIPTION
## Summary
- tighten the README by focusing on core highlights, setup, and examples
- condense the 0.5.0 release notes into a concise highlight list with compatibility call-out
- rebuild TESTING.md to capture the CI-aligned workflow without redundant detail

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f66159423c832f97d89d16a5df76a9