### PR TITLE
Add tests for plain directive placeholders

### DIFF
--- a/compat/ompparser/src/roup_compat.h
+++ b/compat/ompparser/src/roup_compat.h
@@ -11,6 +11,7 @@
 #define ROUP_COMPAT_H
 
 #include <OpenMPIR.h>
+#include <string>
 
 #ifdef __cplusplus
 extern "C" {
@@ -21,6 +22,8 @@ void setLang(OpenMPBaseLang lang);
 
 #ifdef __cplusplus
 }
+
+std::string getPlainDirectiveString(const char* input);
 #endif
 
 #endif /* ROUP_COMPAT_H */

--- a/compat/ompparser/tests/comprehensive_test.cpp
+++ b/compat/ompparser/tests/comprehensive_test.cpp
@@ -139,6 +139,30 @@ TEST(critical_directive) {
     ASSERT_EQ(dir->getKind(), OMPD_critical);
 }
 
+TEST(plain_directive_helper) {
+    setLang(Lang_C);
+    std::string plain = getPlainDirectiveString("omp target data map(to: a) map(from: b)");
+    ASSERT_EQ(plain, "#pragma omp target data map(to: ...) map(from: ...)");
+
+    std::string fallback = getPlainDirectiveString("omp parallel proc_bind(foo)");
+    ASSERT_EQ(fallback, "#pragma omp parallel proc_bind(...)");
+
+    setLang(Lang_Fortran);
+    std::string fortran_plain =
+        getPlainDirectiveString("!$OMP PARALLEL DO REDUCTION(+:SUM)");
+    ASSERT(fortran_plain.find("!$omp parallel") == 0);
+    ASSERT(fortran_plain.find("reduction") != std::string::npos);
+    ASSERT(fortran_plain.find("...") != std::string::npos);
+
+    std::string fortran_fallback =
+        getPlainDirectiveString("!$OMP PARALLEL PROC_BIND(FOO)");
+    ASSERT(fortran_fallback.find("!$omp parallel") == 0);
+    ASSERT(fortran_fallback.find("proc_bind") != std::string::npos);
+    ASSERT(fortran_fallback.find("...") != std::string::npos);
+
+    setLang(Lang_C);
+}
+
 TEST(master_directive) {
     DirectivePtr dir(parseOpenMP("omp master", nullptr));
     ASSERT_NOT_NULL(dir.get());

--- a/docs/plain_directives.md
+++ b/docs/plain_directives.md
@@ -1,0 +1,86 @@
+# Plain Directive Rendering
+
+OpenMP directives often include application-specific identifiers such as variable names,
+array sections, or expressions. For tooling, analytics, or telemetry it is useful to
+examine the *structure* of a directive without exposing those symbols. ROUP now provides
+a "plain" view that keeps directive kinds, clause names, and modifiers while replacing
+user-provided data with the placeholder `...`.
+
+## Rust API
+
+```rust
+use roup::ir::{convert::convert_directive, Language, ParserConfig, SourceLocation};
+use roup::parser::parse_omp_directive;
+
+let input = "#pragma omp target data map(tofrom: a[0:N]) map(to: b[0:N])";
+let (_, parsed) = parse_omp_directive(input)?;
+let config = ParserConfig::with_parsing(Language::C);
+let ir = convert_directive(&parsed, SourceLocation::start(), Language::C, &config)?;
+
+assert_eq!(
+    ir.to_plain_string(),
+    "#pragma omp target data map(tofrom: ...) map(to: ...)"
+);
+```
+
+The [`DirectiveIR::plain`](../src/ir/directive.rs) helper returns a display wrapper if
+you prefer to format directly into an existing buffer. Clauses also expose
+[`ClauseData::to_plain_string`](../src/ir/clause.rs) for granular inspection.
+
+## C API
+
+A new FFI function exposes the same capability:
+
+```c
+const OmpDirective* dir = roup_parse("#pragma omp parallel num_threads(4)");
+const char* plain = roup_directive_plain(dir);
+// plain == "#pragma omp parallel num_threads(...)"
+```
+
+The returned pointer remains valid until `roup_directive_free` is called. The original
+API contracts (null checks, manual memory management) remain unchanged.
+
+### Fortran Support
+
+Both the Rust and C front-ends respect the language-specific sentinel. Passing a
+Fortran directive such as `!$OMP PARALLEL REDUCTION(+:SUM)` produces a plain string
+starting with `!$omp parallel` and clauses rendered with placeholders (for example
+`reduction(...)`). This keeps Fortran and C directives comparable without leaking
+identifiers.
+
+### Fallback Formatting
+
+When semantic conversion fails—typically because the clause payload is invalid or not
+yet modelled—`DirectiveIR::plain` is unavailable. The C API therefore falls back to the
+parser's structural view, emitting clause names with `...` placeholders. For example,
+`#pragma omp parallel proc_bind(foo)` yields `#pragma omp parallel proc_bind(...)`
+instead of bubbling an error. The compatibility layer mirrors this behaviour so existing
+ompparser clients continue to receive usable output even for partially supported
+features.
+
+## ompparser Compatibility Layer
+
+The compatibility shim adds `getPlainDirectiveString(const char*)` in
+[`compat/ompparser/src/roup_compat.h`](../compat/ompparser/src/roup_compat.h). It
+normalises input according to the active language (set via `setLang`) and returns the
+plain directive string without leaking user identifiers:
+
+```cpp
+setLang(Lang_C);
+std::string plain = getPlainDirectiveString("omp parallel reduction(+:sum)");
+// plain == "#pragma omp parallel reduction(+: ...)"
+```
+
+For Fortran inputs the helper automatically injects the sentinel before delegating to
+the Rust parser.
+
+## Limitations
+
+* Unknown or currently unsupported clauses fall back to the parser's structural view.
+* Placeholders are always rendered as `...`; the API does not expose configurable
+  replacement text yet.
+* When IR conversion fails (for example due to a missing feature), the C API and
+  compatibility layer degrade gracefully by showing clause names with placeholders.
+
+These behaviours are covered by new unit, integration, and C++ compatibility tests to
+prevent regressions.

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -45,12 +45,12 @@
 // Re-export main types
 pub use builder::DirectiveBuilder;
 pub use clause::{
-    AtomicOp, ClauseData, ClauseItem, DefaultKind, DependType, DeviceType, LastprivateModifier,
-    LinearModifier, MapType, MemoryOrder, OrderKind, ProcBind, ReductionOperator, ScheduleKind,
-    ScheduleModifier,
+    AtomicOp, ClauseData, ClauseItem, ClauseTemplate, DefaultKind, DependType, DeviceType,
+    LastprivateModifier, LinearModifier, MapType, MemoryOrder, OrderKind, ProcBind,
+    ReductionOperator, ScheduleKind, ScheduleModifier,
 };
 pub use convert::ConversionError;
-pub use directive::{DirectiveIR, DirectiveKind};
+pub use directive::{DirectiveIR, DirectiveKind, DirectiveTemplate};
 pub use expression::{
     BinaryOperator, Expression, ExpressionAst, ExpressionKind, ParserConfig, UnaryOperator,
 };

--- a/tests/plain_directive.rs
+++ b/tests/plain_directive.rs
@@ -1,0 +1,72 @@
+use roup::ir::{convert::convert_directive, Language, ParserConfig, SourceLocation};
+use roup::lexer::Language as LexerLanguage;
+use roup::parser::{openmp, parse_omp_directive};
+use std::ffi::{CStr, CString};
+
+fn convert(input: &str) -> String {
+    let (_, directive) = parse_omp_directive(input).expect("directive should parse");
+    let config = ParserConfig::with_parsing(Language::C);
+    let ir = convert_directive(&directive, SourceLocation::start(), Language::C, &config)
+        .expect("conversion should succeed");
+    ir.to_plain_string()
+}
+
+fn convert_fortran(input: &str) -> String {
+    let parser = openmp::parser().with_language(LexerLanguage::FortranFree);
+    let (_, directive) = parser.parse(input).expect("directive should parse");
+    let config = ParserConfig::with_parsing(Language::Fortran);
+    let ir = convert_directive(
+        &directive,
+        SourceLocation::start(),
+        Language::Fortran,
+        &config,
+    )
+    .expect("conversion should succeed");
+    ir.to_plain_string()
+}
+
+#[test]
+fn plain_string_for_target_data_maps() {
+    let input = "#pragma omp target data map(tofrom: a[0:N]) map(to: b[0:N])";
+    let plain = convert(input);
+    assert_eq!(
+        plain,
+        "#pragma omp target data map(tofrom: ...) map(to: ...)"
+    );
+    assert!(!plain.contains("a[0:N]"));
+    assert!(!plain.contains("b[0:N]"));
+}
+
+#[test]
+fn plain_string_for_parallel_for_with_clauses() {
+    let input =
+        "#pragma omp parallel for if(parallel: n > 0) reduction(+: sum) schedule(dynamic, 8)";
+    let plain = convert(input);
+    assert_eq!(
+        plain,
+        "#pragma omp parallel for if(parallel: ...) reduction(+: ...) schedule(dynamic, ...)",
+    );
+}
+
+#[test]
+fn plain_string_for_fortran_parallel() {
+    let input = "!$omp parallel reduction(+: sum)";
+    let plain = convert_fortran(input);
+    assert!(plain.starts_with("!$omp parallel"));
+    assert!(plain.contains("reduction"));
+    assert!(plain.contains("..."));
+}
+
+#[test]
+fn plain_string_for_invalid_proc_bind_uses_placeholder() {
+    let input = CString::new("#pragma omp parallel proc_bind(foo)").unwrap();
+    let directive = roup::roup_parse(input.as_ptr());
+    assert!(!directive.is_null());
+
+    let plain_ptr = roup::roup_directive_plain(directive);
+    assert!(!plain_ptr.is_null());
+    let plain = unsafe { CStr::from_ptr(plain_ptr) }.to_str().unwrap();
+    assert_eq!(plain, "#pragma omp parallel proc_bind(...)");
+
+    roup::roup_directive_free(directive);
+}


### PR DESCRIPTION
## Summary
- broaden ClauseData and DirectiveIR plain-string tests to cover placeholder rendering, including generic clauses and the Fortran prefix
- exercise the Rust integration, C API, and ompparser compatibility layer to verify fallback plain strings for invalid clauses
- document Fortran support and fallback behaviour for plain directives

## Testing
- cargo test
- ./compat/ompparser/build.sh

------
https://chatgpt.com/codex/tasks/task_e_68ee66102bd4832fb9e244093334587d