### PR TITLE
Add plain directive string support

### DIFF
--- a/compat/ompparser/src/roup_compat.h
+++ b/compat/ompparser/src/roup_compat.h
@@ -19,6 +19,9 @@ extern "C" {
 /* Set the base language for parsing (C, C++, Fortran) */
 void setLang(OpenMPBaseLang lang);
 
+/* Retrieve the normalized plain directive string */
+const char* roup_get_plain_directive_string(const OpenMPDirective* dir);
+
 #ifdef __cplusplus
 }
 #endif

--- a/compat/ompparser/tests/comprehensive_test.cpp
+++ b/compat/ompparser/tests/comprehensive_test.cpp
@@ -195,6 +195,30 @@ TEST(multiple_clauses) {
     ASSERT(clauses->size() >= 2);  // At least num_threads and private
 }
 
+TEST(plain_directive_string_target_map) {
+    const char* source =
+        "#pragma omp target data map(tofrom: a[0:ARRAY_SIZE], num_teams) map(to: b[0:ARRAY_SIZE])";
+    DirectivePtr dir(parseOpenMP(source, nullptr));
+    ASSERT_NOT_NULL(dir.get());
+
+    const char* plain = roup_get_plain_directive_string(dir.get());
+    ASSERT_NOT_NULL(plain);
+    ASSERT_EQ(std::string(plain), "#pragma omp target data map(tofrom: ) map(to: )");
+}
+
+TEST(plain_directive_string_mixed_clauses) {
+    const char* source = "#pragma omp parallel for num_threads(4) if(parallel: flag) reduction(+: sum) schedule(monotonic: static, 16)";
+    DirectivePtr dir(parseOpenMP(source, nullptr));
+    ASSERT_NOT_NULL(dir.get());
+
+    const char* plain = roup_get_plain_directive_string(dir.get());
+    ASSERT_NOT_NULL(plain);
+    ASSERT_EQ(
+        std::string(plain),
+        "#pragma omp parallel for num_threads() if(parallel: ) reduction(+: ) schedule(monotonic: static, )"
+    );
+}
+
 TEST(reduction_clause) {
     DirectivePtr dir(parseOpenMP("omp parallel reduction(+:sum)", nullptr));
     ASSERT_NOT_NULL(dir.get());

--- a/docs/PLAIN_DIRECTIVE_STRINGS.md
+++ b/docs/PLAIN_DIRECTIVE_STRINGS.md
@@ -1,0 +1,57 @@
+# Plain Directive Strings in ROUP
+
+The [ompparser issue #71](https://github.com/passlab/ompparser/issues/71) requests an
+API that returns the structure of an OpenMP directive without exposing the
+user-provided identifiers and expressions. This feature is now supported across
+all ROUP entry points.
+
+## Rust API (`DirectiveIR`)
+
+* `DirectiveIR::to_plain_string()` produces a normalized directive string that
+  preserves the directive kind, clause names, and spec-defined modifiers while
+  removing identifiers, variables, and expressions supplied by the user.
+* Example:
+
+  ```rust
+  use roup::ir::{ClauseData, DirectiveIR, DirectiveKind, Language, MapType, SourceLocation};
+
+  let directive = DirectiveIR::new(
+      DirectiveKind::TargetData,
+      "target data",
+      vec![ClauseData::Map {
+          map_type: Some(MapType::ToFrom),
+          mapper: None,
+          items: vec![],
+      }],
+      SourceLocation::start(),
+      Language::C,
+  );
+
+  assert_eq!(directive.to_plain_string(), "#pragma omp target data map(tofrom: )");
+  ```
+
+## C API
+
+* New field `plain` is stored inside the opaque `OmpDirective`.
+* New function `const char* roup_directive_plain_string(const OmpDirective*)`
+  returns the sanitized string. The pointer remains valid until
+  `roup_directive_free` is called.
+
+## ompparser Compatibility Layer
+
+* `parseOpenMP` stores the plain string in an internal `RoupDirective` subclass.
+* New helper `const char* roup_get_plain_directive_string(const OpenMPDirective*)`
+  exposes the sanitized directive to compatibility users.
+
+## Testing
+
+* Unit tests cover `DirectiveIR::to_plain_string()` for map clauses, mixed
+  clauses, and language prefixes.
+* Integration tests verify the parser → IR → plain-string pipeline and the C
+  API function.
+* Compatibility tests in `comprehensive_test.cpp` assert the plain string for
+  representative directives.
+
+These additions guarantee that every consumer of ROUP can obtain a
+spec-compliant textual skeleton of parsed directives without leaking user
+identifiers.

--- a/tests/openmp_plain_output.rs
+++ b/tests/openmp_plain_output.rs
@@ -1,0 +1,43 @@
+use std::ffi::{CStr, CString};
+
+use roup::ir::{convert::convert_directive, Language as IrLanguage, ParserConfig, SourceLocation};
+use roup::parser::parse_omp_directive;
+use roup::{roup_directive_free, roup_directive_plain_string, roup_parse};
+
+fn expected_plain() -> &'static str {
+    "#pragma omp target data map(tofrom: ) map(to: )"
+}
+
+#[test]
+fn plain_string_from_ir_conversion_matches_expectation() {
+    let source =
+        "#pragma omp target data map(tofrom: a[0:ARRAY_SIZE], num_teams) map(to: b[0:ARRAY_SIZE])";
+    let (_, directive) = parse_omp_directive(source).expect("parser should succeed");
+
+    let config = ParserConfig::with_parsing(IrLanguage::C);
+    let ir = convert_directive(&directive, SourceLocation::start(), IrLanguage::C, &config)
+        .expect("conversion to IR should succeed");
+
+    assert_eq!(ir.to_plain_string(), expected_plain());
+}
+
+#[test]
+fn plain_string_available_through_c_api() {
+    let source = CString::new(
+        "#pragma omp target data map(tofrom: a[0:ARRAY_SIZE], num_teams) map(to: b[0:ARRAY_SIZE])",
+    )
+    .unwrap();
+
+    let directive = roup_parse(source.as_ptr());
+    assert!(!directive.is_null(), "directive should parse");
+
+    let plain_ptr = roup_directive_plain_string(directive);
+    assert!(!plain_ptr.is_null(), "plain string pointer should be valid");
+
+    let plain = unsafe { CStr::from_ptr(plain_ptr) }
+        .to_str()
+        .expect("valid UTF-8");
+    assert_eq!(plain, expected_plain());
+
+    roup_directive_free(directive);
+}


### PR DESCRIPTION
## Summary
- add reusable display modes so `DirectiveIR::to_plain_string()` can emit sanitized directives without user symbols
- expose the plain directive string through the C API and the ompparser compatibility layer with accompanying tests
- document the feature and add integration coverage for both the Rust and C front doors

## Testing
- `cargo test`
- `cmake ..` *(fails: ompparser submodule not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_68ee66102bd4832fb9e244093334587d