### PR TITLE
Modernize Pages CI and adopt Rust 2024

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: true
       matrix:
         rust: ["1.88", stable]
-        os: [ubuntu-24.04, windows-2025, macos-15]
+        os: [ubuntu-26.04, windows-2025, macos-26]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
@@ -52,7 +52,7 @@ jobs:
 
   integration:
     name: C ABI, adapters, examples, and documentation
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
         with:
@@ -77,7 +77,10 @@ jobs:
   documentation:
     name: Build documentation artifact
     needs: [rust, integration]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
+    permissions:
+      contents: read
+      pages: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -105,8 +108,13 @@ jobs:
           mkdir -p docs/book/book/api
           cp -R target/doc/. docs/book/book/api/
 
-      - uses: actions/configure-pages@v6
-      - uses: actions/upload-pages-artifact@v5
+      - name: Configure GitHub Pages
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && !env.ACT }}
+        uses: actions/configure-pages@v6
+
+      - name: Upload Pages artifact
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && !env.ACT }}
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/book/book
 
@@ -114,8 +122,10 @@ jobs:
     name: Deploy documentation
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: documentation
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
+      actions: read
+      contents: read
       pages: write
       id-token: write
     environment:
@@ -123,5 +133,6 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy GitHub Pages
+        if: ${{ !env.ACT }}
         id: deployment
         uses: actions/deploy-pages@v5

--- a/.github/workflows/codex-after-ci.yml
+++ b/.github/workflows/codex-after-ci.yml
@@ -7,7 +7,7 @@ name: Codex review (after CI success)
 # REQUIRES: Repository secret 'CODEX_COMMENT_TOKEN' - Personal Access Token with:
 #   - Permissions: pull_requests: write (to post comments as user)
 #   - Scopes: repo (for private repos) or public_repo (for public repos)
-# Without PAT, comments will be posted as github-actions[bot] and Copilot won't respond
+# Without the PAT, the comment step fails instead of silently using another identity.
 
 on:
   workflow_run:
@@ -27,7 +27,7 @@ jobs:
     if: >
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: Debug workflow run info
         run: |
@@ -35,26 +35,59 @@ jobs:
           echo "Workflow event: ${{ github.event.workflow_run.event }}"
           echo "Workflow name: ${{ github.event.workflow_run.name }}"
           echo "Pull requests: ${{ toJson(github.event.workflow_run.pull_requests) }}"
-      
+
       - name: Get PR number
         id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_PULL_REQUESTS: ${{ toJson(github.event.workflow_run.pull_requests) }}
         run: |
-          prs='${{ toJson(github.event.workflow_run.pull_requests) }}'
-          echo "PRs JSON: $prs"
-          
-          # Use jq to reliably check if array is empty
-          if echo "$prs" | jq -e 'length == 0' >/dev/null || [ -z "$prs" ]; then
-            echo "No PR found for this workflow run"
-            echo "pr=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          
-          pr_number=$(echo "$prs" | jq -r '.[0].number')
+          set -euo pipefail
+
+          payload_count=$(jq -er '
+            if type == "array" then length
+            else error("workflow_run.pull_requests is not an array")
+            end
+          ' <<< "$WORKFLOW_PULL_REQUESTS")
+
+          case "$payload_count" in
+            0)
+              if [ -z "$WORKFLOW_HEAD_SHA" ]; then
+                echo "error: workflow_run.head_sha is empty" >&2
+                exit 1
+              fi
+
+              associated_prs=$(gh api \
+                --header "Accept: application/vnd.github+json" \
+                "repos/$GITHUB_REPOSITORY/commits/$WORKFLOW_HEAD_SHA/pulls")
+              api_count=$(jq -er '
+                if type == "array" then [.[] | select(.state == "open")] | length
+                else error("associated pull-request response is not an array")
+                end
+              ' <<< "$associated_prs")
+              if [ "$api_count" -ne 1 ]; then
+                echo "error: expected exactly one open PR for workflow head $WORKFLOW_HEAD_SHA, found $api_count" >&2
+                exit 1
+              fi
+              pr_number=$(jq -er \
+                '[.[] | select(.state == "open")][0].number | select(type == "number")' \
+                <<< "$associated_prs")
+              ;;
+            1)
+              pr_number=$(jq -er '.[0].number | select(type == "number")' \
+                <<< "$WORKFLOW_PULL_REQUESTS")
+              ;;
+            *)
+              echo "error: expected at most one workflow_run PR, found $payload_count" >&2
+              exit 1
+              ;;
+          esac
+
           echo "Found PR number: $pr_number"
           echo "pr=$pr_number" >> "$GITHUB_OUTPUT"
 
       - name: Post @codex review comment
-        if: steps.pr.outputs.pr != ''
         env:
           # Use PAT to post as user instead of github-actions bot
           # This allows Copilot to respond to the @codex mention

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -165,18 +165,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -248,13 +248,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -266,9 +265,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "nom"
@@ -355,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -384,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -396,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -407,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "roup"
@@ -429,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "same-file"
@@ -499,9 +498,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -536,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -549,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -559,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -572,18 +571,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -637,18 +636,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "roup"
 version = "0.8.0"
 authors = ["Anjia Wang <anjia@ouankou.com>"]
-edition = "2021"
-rust-version = "1.88.0"  # MSRV: Verified against current dependencies
+edition = "2024"
+rust-version = "1.88.0"  # MSRV: Verified against all required Rust dependencies and tools
 license = "BSD-3-Clause"
 description = "Safe Rust parser for typed OpenMP and OpenACC directive ASTs"
 repository = "https://github.com/ouankou/roup"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,23 @@
   fail when an upstream IR cannot faithfully represent a parsed payload.
 - Replaced round-trip and permissive external-corpus gates with focused strict
   syntax, semantic-fact, ABI, adapter, and cross-language regression tests.
+- Made Fortran continuation handling dialect-aware: standard OpenACC sentinels
+  are stripped from continued OpenACC directives, while cross-dialect
+  continuation sentinels are hard errors.
+- Hardened documentation publication as a GitHub Pages Actions artifact
+  deployment and moved Linux and macOS CI to the Ubuntu 26.04 and macOS 26
+  hosted runners.
+- Refreshed the complete Cargo dependency lockfile to the newest available
+  releases while retaining the verified Rust 1.88.0 repository MSRV required
+  by the complete dependency and tooling graph.
+- Migrated both workspace crates to the Rust 2024 edition, including explicit
+  C export attributes and preserved mutex-guard drop ordering at the ABI
+  service boundary.
+
+> The versioned entries below describe each historical release at the time it
+> shipped. They may mention binaries, validation scripts, or FFI designs that
+> the breaking unreleased refactor above has intentionally removed. Use the
+> current README, book, and checked C header as the present API reference.
 
 ## 0.7.0 (2025-11-25)
 
@@ -69,7 +86,8 @@ None. All Rust, C, and C++ APIs remain backward compatible.
 - Rust entry point: `translate::translate()` detects the input format.
 - C API wrappers: `roup_translate_c_to_fortran()` and `roup_translate_fortran_to_c()`.
 - Handles both free-form and fixed-form Fortran, including column-7 sentinels.
-- See the [Translation API docs](https://roup.ouankou.com/api-reference.html#translation-api) for examples.
+- The then-current translation guide was removed with the breaking refactor
+  described in the unreleased section above.
 
 ### OpenMP_VV validation
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -43,6 +43,8 @@ The first failure terminates the run.
 
 ## Toolchain policy
 
-The minimum supported Rust version is 1.88. CI tests Rust 1.88 and the current
-stable release on Linux, Windows, and macOS. The Linux integration job also
-runs the complete native and documentation gate.
+The minimum supported Rust version is 1.88, the highest minimum required by
+the complete Rust dependency and tooling graph, including the required pinned
+mdBook. CI tests Rust 1.88 and the current stable release on Ubuntu 26.04,
+Windows 2025, and macOS 26. The Ubuntu integration job also runs the complete
+native and documentation gate.

--- a/benches/line_continuations.rs
+++ b/benches/line_continuations.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use roup::api::OpenMpConfig;
 use roup::version::{CStandard, FortranStandard, HostLanguageProfile, SourceForm};
 use std::hint::black_box;

--- a/compat/ompparser/STRICT_AUDIT.md
+++ b/compat/ompparser/STRICT_AUDIT.md
@@ -23,71 +23,43 @@ hard-error expectation; it is never accepted or removed from the evidence.
 No fixture or source file is discovered by glob. Missing pinned files, changed
 fixture hashes, and changed exact correction evidence fail configuration. A
 parse exception, output mismatch, missing expectation, nonzero runner result,
-or timeout fails CTest. The larger builtin, OpenMP-VV, and example corpora remain evidence for
-future audit expansion; they are not silently skipped tests and are not the
-strict adapter contract because they mix invalid legacy acceptance, historical
-surface rendering, and whole-source harvesting.
+or timeout fails CTest. The larger builtin, OpenMP-VV, and example corpora
+remain evidence for future audit expansion; they are not silently skipped tests
+and are not the strict adapter contract because they mix invalid legacy
+acceptance, historical surface rendering, and whole-source harvesting.
 
-## Confirmed frontend/legality issues
+## Frontend and legality issues fixed during this audit
 
-- `#pragma omp declare mapper(myvec_t v) map(v, v.data[0:v.len])`
-  - Diagnostic 3003: `OpenMP clause Map is not allowed on directive DeclareMapper`.
-  - A `declare mapper` directive is defined by its mapper declaration followed
-    by one or more `map` clauses.
-- `#pragma omp declare mapper(short * a) map(to :w,e,r)`
-  - Diagnostic 3003: `OpenMP clause Map is not allowed on directive DeclareMapper`.
-  - The C declaration `short *a` must remain a type/declarator pair rather than
-    being reduced to an identifier string.
-- `#pragma omp declare mapper(default : const int *a)`
-  - Diagnostic 3002: `identifier cannot start with '*'`.
-  - The type/declarator split incorrectly assigns the pointer star to the
-    variable identifier.
-- `#pragma omp declare target (x,y,z)` and `!$omp declare target(s,t,f)`
-  - Diagnostic 3002: `identifier cannot start with '('`.
-  - This is the historical extended-list form and must stay accepted even
-    though canonical output may use the current spelling.
-- `!$omp end critical(test3)`
-  - Diagnostic 2001 with unconsumed input `(test3)`.
-  - A named Fortran critical construct repeats its name on `end critical`.
-- `!$omp end do nowait`, `!$omp end do simd nowait`,
-  `!$omp end sections nowait`, `!$omp end single nowait`, and
-  `!$omp end workshare nowait`
-  - Diagnostic 3003 says `Nowait` is not allowed on the respective terminating
-    directive.
-  - Fortran attaches these construct clauses to the terminating directive.
-- `!$omp end single copyprivate(to,b,c)`
-  - Diagnostic 3003: `Copyprivate` is not allowed on `EndSingle`.
-  - `copyprivate` is a standard clause on the Fortran `end single` directive.
-- `#pragma omp loop private(a,b,c)`,
-  `#pragma omp loop lastprivate(conditional:a,b,c)`, and
-  `#pragma omp loop reduction(default,max:a,b,c)`
-  - Diagnostic 3003 rejects `Private`, `Lastprivate`, and `Reduction` on `Loop`.
-  - These are standard loop data-environment clauses. Equivalent Fortran
-    inputs fail the same way.
-- `#pragma omp simd private(a,b,c)` and the corresponding `lastprivate` case
-  - Diagnostic 3003 rejects the standard SIMD data-environment clauses.
-- `#pragma omp master taskloop grainsize(3)` (and the other taskloop clauses in
-  the pinned `master_taskloop*.txt` fixtures)
-  - Diagnostic 3003 rejects taskloop clauses on the historical
-    `master taskloop` combined construct.
-  - The deprecated construct spelling remains required compatibility syntax;
-    it must inherit taskloop clause legality and may canonicalize its name.
-- `#pragma omp parallel loop bind(parallel)` and
-  `#pragma omp teams loop bind(teams)`
-  - Diagnostic 3003 rejects `Bind` on `ParallelLoop` and `TeamsLoop`.
-  - The combined loop forms retain the `bind` semantics of their loop region.
-- `#pragma omp requires ext_user_test reverse_offload unified_address unified_shared_memory,atomic_default_mem_order(acq_rel) dynamic_allocators`
-  - Diagnostic 2001 leaves all requirements after `ext_user_test` unconsumed.
-  - A requires directive contains an ordered sequence of requirement clauses;
-    the parser currently stops after the first implementation-defined one.
+The initial pinned-fixture failures exposed frontend bugs rather than adapter
+workarounds. They are fixed in the typed parser and retained as public-API
+regressions, primarily in `tests/openmp_historical_legality.rs`:
+
+- `declare mapper` now accepts its required `map` clauses and stores the mapper
+  type/declarator split structurally, including adjacent and spaced pointer
+  stars. Missing variables, array declarators, and missing map clauses remain
+  hard errors.
+- Historical C/C++ and Fortran `declare target` extended lists remain accepted
+  in later exact-version modes and use a dedicated typed parameter variant.
+- Named Fortran `end critical` parameters and the standardized `nowait` and
+  `copyprivate` end-directive clauses are retained instead of left unconsumed
+  or rejected by the wrong clause table.
+- `loop` and `simd` expose their standardized data-environment clauses, while
+  `parallel loop` and `teams loop` retain the `bind` semantics inherited from
+  their loop constituent.
+- Historical `master taskloop` and `master taskloop simd` spellings remain
+  cumulatively accepted and inherit their taskloop and SIMD clause sets.
+- A `requires` directive retains each standardized requirement as an ordered
+  typed clause. Unknown bare implementation spellings are hard errors rather
+  than partially consumed extension payloads.
 
 ## Adapter issues fixed during this audit
 
 - Directive and clause kinds are selected only from the C ABI's numeric
   OpenMP ordinals. The adapter has an explicit exhaustive mapping for all 194
-  directive ordinals and all 133 clause ordinals; every end ordinal maps to a
-  concrete paired construct, including `end allocators` and `end dispatch`.
-  Names are never queried and unknown ordinals are hard errors.
+  directive ordinals and all 132 clause ordinals at this audit revision; every
+  end ordinal maps to a concrete paired construct, including `end allocators`
+  and `end dispatch`. Names are never queried and unknown ordinals are hard
+  errors.
 - Closed clause semantics use scalar/list U32 fields, booleans use the
   dedicated boolean getter, and structured semantics use node families.
   Strings are restricted to identifiers, type names, expressions, and literal

--- a/crates/roup-capi/Cargo.toml
+++ b/crates/roup-capi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "roup-capi"
 version = "0.8.0"
-edition = "2021"
+edition = "2024"
 rust-version = "1.88.0"
 license = "BSD-3-Clause"
 description = "Optional C ABI for the ROUP parser"

--- a/crates/roup-capi/src/boundary.rs
+++ b/crates/roup-capi/src/boundary.rs
@@ -8,16 +8,16 @@ use core::fmt;
 use core::ptr;
 use core::slice;
 use core::str;
-use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use crate::service::{self, Failure, ServiceResult};
 use crate::{
-    RoupCallResult, RoupClauseKind, RoupClauseKindResult, RoupDirectiveHandle, RoupDirectiveKind,
-    RoupDirectiveKindResult, RoupDirectiveResult, RoupErrorHandle, RoupFieldInfo,
-    RoupFieldInfoResult, RoupNodeHandle, RoupNodeKind, RoupNodeKindResult, RoupNodeResult,
-    RoupParameterKind, RoupParameterKindResult, RoupParserHandle, RoupParserOptions,
-    RoupParserResult, RoupSizeResult, RoupSpan, RoupSpanResult, RoupU32Result, RoupU64Result,
-    ROUP_ABI_VERSION,
+    ROUP_ABI_VERSION, RoupCallResult, RoupClauseKind, RoupClauseKindResult, RoupDirectiveHandle,
+    RoupDirectiveKind, RoupDirectiveKindResult, RoupDirectiveResult, RoupErrorHandle,
+    RoupFieldInfo, RoupFieldInfoResult, RoupNodeHandle, RoupNodeKind, RoupNodeKindResult,
+    RoupNodeResult, RoupParameterKind, RoupParameterKindResult, RoupParserHandle,
+    RoupParserOptions, RoupParserResult, RoupSizeResult, RoupSpan, RoupSpanResult, RoupU32Result,
+    RoupU64Result,
 };
 
 /// A hard failure while validating a caller-provided buffer.
@@ -209,19 +209,19 @@ unsafe fn string_copy(
 }
 
 /// Return the implemented ABI version.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_abi_version() -> RoupU32Result {
     RoupU32Result::success(ROUP_ABI_VERSION)
 }
 
 /// Create a strict OpenMP or OpenACC parser from validated raw options.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_parser_create(options: RoupParserOptions) -> RoupParserResult {
     invoke(|| service::create_parser(options))
 }
 
 /// Release a parser handle. Existing directive handles remain independently owned.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_parser_release(parser: RoupParserHandle) -> RoupCallResult {
     invoke(|| service::release_parser(parser))
 }
@@ -231,7 +231,7 @@ pub extern "C" fn roup_parser_release(parser: RoupParserHandle) -> RoupCallResul
 /// # Safety
 ///
 /// `input` must satisfy [`copy_utf8_input`]'s safety contract.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn roup_parse(
     parser: RoupParserHandle,
     input: *const u8,
@@ -247,46 +247,46 @@ pub unsafe extern "C" fn roup_parse(
 }
 
 /// Release an owned directive handle.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_directive_release(directive: RoupDirectiveHandle) -> RoupCallResult {
     invoke(|| service::release_directive(directive))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_directive_dialect(directive: RoupDirectiveHandle) -> RoupU32Result {
     invoke(|| service::directive_dialect(directive))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_directive_kind(directive: RoupDirectiveHandle) -> RoupDirectiveKindResult {
     invoke(|| service::directive_kind(directive))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_directive_span(directive: RoupDirectiveHandle) -> RoupSpanResult {
     invoke(|| service::directive_span(directive))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_directive_has_parameter(directive: RoupDirectiveHandle) -> RoupU32Result {
     invoke(|| service::directive_has_parameter(directive))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_directive_parameter_kind(
     directive: RoupDirectiveHandle,
 ) -> RoupParameterKindResult {
     invoke(|| service::directive_parameter_kind(directive))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_directive_parameter_field_count(
     directive: RoupDirectiveHandle,
 ) -> RoupSizeResult {
     invoke(|| service::directive_parameter_field_count(directive))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_directive_parameter_field_info(
     directive: RoupDirectiveHandle,
     field_index: usize,
@@ -294,7 +294,7 @@ pub extern "C" fn roup_directive_parameter_field_info(
     invoke(|| service::directive_parameter_field_info(directive, field_index))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_directive_parameter_field_name_length(
     directive: RoupDirectiveHandle,
     field_index: usize,
@@ -307,7 +307,7 @@ pub extern "C" fn roup_directive_parameter_field_name_length(
 /// # Safety
 ///
 /// `output` must satisfy [`copy_utf8_output`]'s safety contract.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn roup_directive_parameter_field_name_copy(
     directive: RoupDirectiveHandle,
     field_index: usize,
@@ -324,7 +324,7 @@ pub unsafe extern "C" fn roup_directive_parameter_field_name_copy(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_directive_parameter_field_u32(
     directive: RoupDirectiveHandle,
     field_index: usize,
@@ -333,7 +333,7 @@ pub extern "C" fn roup_directive_parameter_field_u32(
     invoke(|| service::directive_parameter_field_u32(directive, field_index, value_index))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_directive_parameter_field_u64(
     directive: RoupDirectiveHandle,
     field_index: usize,
@@ -342,7 +342,7 @@ pub extern "C" fn roup_directive_parameter_field_u64(
     invoke(|| service::directive_parameter_field_u64(directive, field_index, value_index))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_directive_parameter_field_bool(
     directive: RoupDirectiveHandle,
     field_index: usize,
@@ -351,7 +351,7 @@ pub extern "C" fn roup_directive_parameter_field_bool(
     invoke(|| service::directive_parameter_field_bool(directive, field_index, value_index))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_directive_parameter_field_string_length(
     directive: RoupDirectiveHandle,
     field_index: usize,
@@ -365,7 +365,7 @@ pub extern "C" fn roup_directive_parameter_field_string_length(
 /// # Safety
 ///
 /// `output` must satisfy [`copy_utf8_output`]'s safety contract.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn roup_directive_parameter_field_string_copy(
     directive: RoupDirectiveHandle,
     field_index: usize,
@@ -384,7 +384,7 @@ pub unsafe extern "C" fn roup_directive_parameter_field_string_copy(
 }
 
 /// Acquire an independently owned semantic child-node handle.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_directive_parameter_field_node(
     directive: RoupDirectiveHandle,
     field_index: usize,
@@ -393,7 +393,7 @@ pub extern "C" fn roup_directive_parameter_field_node(
     invoke(|| service::directive_parameter_field_node(directive, field_index, value_index))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_directive_name_length(directive: RoupDirectiveHandle) -> RoupSizeResult {
     string_length(|| service::directive_name(directive))
 }
@@ -403,7 +403,7 @@ pub extern "C" fn roup_directive_name_length(directive: RoupDirectiveHandle) -> 
 /// # Safety
 ///
 /// `output` must satisfy [`copy_utf8_output`]'s safety contract.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn roup_directive_name_copy(
     directive: RoupDirectiveHandle,
     output: *mut u8,
@@ -413,19 +413,19 @@ pub unsafe extern "C" fn roup_directive_name_copy(
     unsafe { string_copy(|| service::directive_name(directive), output, capacity) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_directive_clause_count(directive: RoupDirectiveHandle) -> RoupSizeResult {
     invoke(|| service::directive_clause_count(directive))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_directive_compatible_versions(
     directive: RoupDirectiveHandle,
 ) -> RoupU64Result {
     invoke(|| service::directive_compatible_versions(directive))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_clause_kind(
     directive: RoupDirectiveHandle,
     clause_index: usize,
@@ -433,7 +433,7 @@ pub extern "C" fn roup_clause_kind(
     invoke(|| service::clause_kind(directive, clause_index))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_clause_span(
     directive: RoupDirectiveHandle,
     clause_index: usize,
@@ -441,7 +441,7 @@ pub extern "C" fn roup_clause_span(
     invoke(|| service::clause_span(directive, clause_index))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_clause_name_length(
     directive: RoupDirectiveHandle,
     clause_index: usize,
@@ -454,7 +454,7 @@ pub extern "C" fn roup_clause_name_length(
 /// # Safety
 ///
 /// `output` must satisfy [`copy_utf8_output`]'s safety contract.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn roup_clause_name_copy(
     directive: RoupDirectiveHandle,
     clause_index: usize,
@@ -471,7 +471,7 @@ pub unsafe extern "C" fn roup_clause_name_copy(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_clause_field_count(
     directive: RoupDirectiveHandle,
     clause_index: usize,
@@ -479,7 +479,7 @@ pub extern "C" fn roup_clause_field_count(
     invoke(|| service::clause_field_count(directive, clause_index))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_clause_field_info(
     directive: RoupDirectiveHandle,
     clause_index: usize,
@@ -488,7 +488,7 @@ pub extern "C" fn roup_clause_field_info(
     invoke(|| service::clause_field_info(directive, clause_index, field_index))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_clause_field_name_length(
     directive: RoupDirectiveHandle,
     clause_index: usize,
@@ -502,7 +502,7 @@ pub extern "C" fn roup_clause_field_name_length(
 /// # Safety
 ///
 /// `output` must satisfy [`copy_utf8_output`]'s safety contract.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn roup_clause_field_name_copy(
     directive: RoupDirectiveHandle,
     clause_index: usize,
@@ -520,7 +520,7 @@ pub unsafe extern "C" fn roup_clause_field_name_copy(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_clause_field_u32(
     directive: RoupDirectiveHandle,
     clause_index: usize,
@@ -530,7 +530,7 @@ pub extern "C" fn roup_clause_field_u32(
     invoke(|| service::clause_field_u32(directive, clause_index, field_index, value_index))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_clause_field_u64(
     directive: RoupDirectiveHandle,
     clause_index: usize,
@@ -540,7 +540,7 @@ pub extern "C" fn roup_clause_field_u64(
     invoke(|| service::clause_field_u64(directive, clause_index, field_index, value_index))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_clause_field_bool(
     directive: RoupDirectiveHandle,
     clause_index: usize,
@@ -550,7 +550,7 @@ pub extern "C" fn roup_clause_field_bool(
     invoke(|| service::clause_field_bool(directive, clause_index, field_index, value_index))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_clause_field_string_length(
     directive: RoupDirectiveHandle,
     clause_index: usize,
@@ -567,7 +567,7 @@ pub extern "C" fn roup_clause_field_string_length(
 /// # Safety
 ///
 /// `output` must satisfy [`copy_utf8_output`]'s safety contract.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn roup_clause_field_string_copy(
     directive: RoupDirectiveHandle,
     clause_index: usize,
@@ -587,7 +587,7 @@ pub unsafe extern "C" fn roup_clause_field_string_copy(
 }
 
 /// Acquire an independently owned semantic child-node handle.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_clause_field_node(
     directive: RoupDirectiveHandle,
     clause_index: usize,
@@ -597,17 +597,17 @@ pub extern "C" fn roup_clause_field_node(
     invoke(|| service::clause_field_node(directive, clause_index, field_index, value_index))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_node_kind(node: RoupNodeHandle) -> RoupNodeKindResult {
     invoke(|| service::node_kind(node))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_node_field_count(node: RoupNodeHandle) -> RoupSizeResult {
     invoke(|| service::node_field_count(node))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_node_field_info(
     node: RoupNodeHandle,
     field_index: usize,
@@ -615,7 +615,7 @@ pub extern "C" fn roup_node_field_info(
     invoke(|| service::node_field_info(node, field_index))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_node_field_name_length(
     node: RoupNodeHandle,
     field_index: usize,
@@ -628,7 +628,7 @@ pub extern "C" fn roup_node_field_name_length(
 /// # Safety
 ///
 /// `output` must satisfy [`copy_utf8_output`]'s safety contract.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn roup_node_field_name_copy(
     node: RoupNodeHandle,
     field_index: usize,
@@ -645,7 +645,7 @@ pub unsafe extern "C" fn roup_node_field_name_copy(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_node_field_u32(
     node: RoupNodeHandle,
     field_index: usize,
@@ -654,7 +654,7 @@ pub extern "C" fn roup_node_field_u32(
     invoke(|| service::node_field_u32(node, field_index, value_index))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_node_field_u64(
     node: RoupNodeHandle,
     field_index: usize,
@@ -663,7 +663,7 @@ pub extern "C" fn roup_node_field_u64(
     invoke(|| service::node_field_u64(node, field_index, value_index))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_node_field_bool(
     node: RoupNodeHandle,
     field_index: usize,
@@ -672,7 +672,7 @@ pub extern "C" fn roup_node_field_bool(
     invoke(|| service::node_field_bool(node, field_index, value_index))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_node_field_string_length(
     node: RoupNodeHandle,
     field_index: usize,
@@ -686,7 +686,7 @@ pub extern "C" fn roup_node_field_string_length(
 /// # Safety
 ///
 /// `output` must satisfy [`copy_utf8_output`]'s safety contract.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn roup_node_field_string_copy(
     node: RoupNodeHandle,
     field_index: usize,
@@ -705,7 +705,7 @@ pub unsafe extern "C" fn roup_node_field_string_copy(
 }
 
 /// Acquire an independently owned nested semantic child-node handle.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_node_field_node(
     node: RoupNodeHandle,
     field_index: usize,
@@ -714,22 +714,22 @@ pub extern "C" fn roup_node_field_node(
     invoke(|| service::node_field_node(node, field_index, value_index))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_node_release(node: RoupNodeHandle) -> RoupCallResult {
     invoke(|| service::release_node(node))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_error_code(error: RoupErrorHandle) -> RoupU32Result {
     invoke(|| service::error_code(error))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_error_span(error: RoupErrorHandle) -> RoupSpanResult {
     invoke(|| service::error_span(error))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_error_message_length(error: RoupErrorHandle) -> RoupSizeResult {
     string_length(|| service::error_message(error))
 }
@@ -739,7 +739,7 @@ pub extern "C" fn roup_error_message_length(error: RoupErrorHandle) -> RoupSizeR
 /// # Safety
 ///
 /// `output` must satisfy [`copy_utf8_output`]'s safety contract.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn roup_error_message_copy(
     error: RoupErrorHandle,
     output: *mut u8,
@@ -750,7 +750,7 @@ pub unsafe extern "C" fn roup_error_message_copy(
 }
 
 /// Release an error handle after all diagnostic fields have been copied.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn roup_error_release(error: RoupErrorHandle) -> RoupCallResult {
     invoke(|| service::release_error(error))
 }
@@ -759,7 +759,7 @@ pub extern "C" fn roup_error_release(error: RoupErrorHandle) -> RoupCallResult {
 mod tests {
     use super::*;
     use crate::{
-        RoupStatus, ROUP_DIALECT_OPENMP, ROUP_HOST_C, ROUP_SOURCE_PRAGMA, ROUP_VERSION_ANY,
+        ROUP_DIALECT_OPENMP, ROUP_HOST_C, ROUP_SOURCE_PRAGMA, ROUP_VERSION_ANY, RoupStatus,
     };
 
     fn openmp_options() -> RoupParserOptions {

--- a/crates/roup-capi/src/service.rs
+++ b/crates/roup-capi/src/service.rs
@@ -3,14 +3,14 @@
 use crate::boundary::BoundaryError;
 use crate::handle::{GenerationalArena, Handle, HandleError};
 use crate::{
+    ROUP_ABI_VERSION, ROUP_DIAGNOSTIC_BUFFER_TOO_SMALL, ROUP_DIAGNOSTIC_INDEX_OUT_OF_RANGE,
+    ROUP_DIAGNOSTIC_INTERNAL_ERROR, ROUP_DIAGNOSTIC_INVALID_HANDLE,
+    ROUP_DIAGNOSTIC_INVALID_POINTER, ROUP_DIAGNOSTIC_INVALID_UTF8, ROUP_DIALECT_OPENACC,
+    ROUP_DIALECT_OPENMP, ROUP_HOST_C, ROUP_HOST_CPP, ROUP_HOST_FORTRAN, ROUP_SOURCE_FORTRAN_FIXED,
+    ROUP_SOURCE_FORTRAN_FREE, ROUP_SOURCE_PRAGMA, ROUP_VERSION_ANY, ROUP_VERSION_EXACT,
     RoupClauseKind, RoupDirectiveHandle, RoupDirectiveKind, RoupErrorHandle, RoupFieldInfo,
     RoupNodeHandle, RoupNodeKind, RoupParameterKind, RoupParserHandle, RoupParserOptions, RoupSpan,
-    RoupStatus, ROUP_ABI_VERSION, ROUP_DIAGNOSTIC_BUFFER_TOO_SMALL,
-    ROUP_DIAGNOSTIC_INDEX_OUT_OF_RANGE, ROUP_DIAGNOSTIC_INTERNAL_ERROR,
-    ROUP_DIAGNOSTIC_INVALID_HANDLE, ROUP_DIAGNOSTIC_INVALID_POINTER, ROUP_DIAGNOSTIC_INVALID_UTF8,
-    ROUP_DIALECT_OPENACC, ROUP_DIALECT_OPENMP, ROUP_HOST_C, ROUP_HOST_CPP, ROUP_HOST_FORTRAN,
-    ROUP_SOURCE_FORTRAN_FIXED, ROUP_SOURCE_FORTRAN_FREE, ROUP_SOURCE_PRAGMA, ROUP_VERSION_ANY,
-    ROUP_VERSION_EXACT,
+    RoupStatus,
 };
 use roup::api::{OpenAccConfig, OpenAccParser, OpenMpConfig, OpenMpParser};
 use roup::ast::{
@@ -902,10 +902,12 @@ fn lock_state() -> Result<MutexGuard<'static, State>, Failure> {
 
 fn with_state<T>(operation: impl FnOnce(&mut State) -> UnrecordedResult<T>) -> ServiceResult<T> {
     let mut state = lock_state()?;
-    match operation(&mut state) {
+    let result = match operation(&mut state) {
         Ok(value) => Ok(value),
         Err(unrecorded) => Err(state.record(unrecorded)),
-    }
+    };
+    drop(state);
+    result
 }
 
 pub(crate) fn record_internal(message: impl Into<String>) -> Failure {
@@ -1840,7 +1842,7 @@ fn validate_options(options: RoupParserOptions) -> UnrecordedResult<ParserRecord
             value => {
                 return Err(config_error(format!(
                     "unknown C language standard value {value}"
-                )))
+                )));
             }
         }),
         ROUP_HOST_CPP => HostLanguageProfile::Cpp(match options.host_standard {
@@ -1853,7 +1855,7 @@ fn validate_options(options: RoupParserOptions) -> UnrecordedResult<ParserRecord
             value => {
                 return Err(config_error(format!(
                     "unknown C++ language standard value {value}"
-                )))
+                )));
             }
         }),
         ROUP_HOST_FORTRAN => HostLanguageProfile::Fortran(match options.host_standard {
@@ -1867,7 +1869,7 @@ fn validate_options(options: RoupParserOptions) -> UnrecordedResult<ParserRecord
             value => {
                 return Err(config_error(format!(
                     "unknown Fortran language standard value {value}"
-                )))
+                )));
             }
         }),
         value => return Err(config_error(format!("unknown host language value {value}"))),
@@ -5143,9 +5145,11 @@ mod tests {
 
         assert_eq!(failure.status, RoupStatus::INVALID_ARGUMENT);
         assert_eq!(error_code(failure.error).unwrap(), 1000);
-        assert!(error_message(failure.error)
-            .unwrap()
-            .contains("unknown C language standard"));
+        assert!(
+            error_message(failure.error)
+                .unwrap()
+                .contains("unknown C language standard")
+        );
         release_error(failure.error).unwrap();
     }
 
@@ -5859,9 +5863,11 @@ mod tests {
             only_field(fields, crate::ROUP_FIELD_ALLOCATOR_EXPRESSION),
             FieldValue::String(expression) if expression == "select_allocator(device)"
         ));
-        assert!(fields
-            .iter()
-            .all(|field| field.id != crate::ROUP_FIELD_ALIGNMENT_EXPRESSION));
+        assert!(
+            fields
+                .iter()
+                .all(|field| field.id != crate::ROUP_FIELD_ALIGNMENT_EXPRESSION)
+        );
         assert!(matches!(
             only_field(fields, crate::ROUP_FIELD_ALLOCATE_SOURCE_SYNTAX),
             FieldValue::U32(crate::ROUP_OMP_ALLOCATE_SOURCE_SIMPLE_ALLOCATOR)

--- a/docs/OPENACC_SUPPORT.md
+++ b/docs/OPENACC_SUPPORT.md
@@ -49,6 +49,7 @@ error.
 
 Regression coverage is organized around the public typed API in
 `tests/openacc_public_api.rs`, `tests/openacc_directive_parameters.rs`,
-`tests/feature_availability.rs`, `tests/host_profile_gates.rs`, and the strict
-payload and error suites. The optional `roup-capi` crate and accparser adapter
-are tested separately from the safe Rust parser.
+`tests/openacc_line_continuations.rs`, `tests/feature_availability.rs`,
+`tests/host_profile_gates.rs`, and the strict payload and error suites. The
+optional `roup-capi` crate and accparser adapter are tested separately from the
+safe Rust parser.

--- a/docs/OPENMP_SUPPORT.md
+++ b/docs/OPENMP_SUPPORT.md
@@ -57,5 +57,5 @@ directive sequence.
 
 Public-API regression coverage includes `tests/feature_availability.rs`,
 `tests/context_validation.rs`, `tests/host_profile_gates.rs`,
-`tests/source_span_regressions.rs`, `tests/openmp_directive_parameters.rs`, and
-the strict payload and error suites.
+`tests/source_span_regressions.rs`, `tests/openmp_directive_parameters.rs`,
+`tests/openmp_historical_legality.rs`, and the strict payload and error suites.

--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -9,6 +9,9 @@ The `docs/book` directory hosts the mdBook sources for https://roup.ouankou.com.
   `cargo doc --locked --workspace --no-deps`
   to bundle the Rust API reference alongside the book.
 
-The documentation job in `.github/workflows/ci.yml` tests both outputs, combines
-them, and publishes the resulting artifact from `main`. The `book.toml`
+The documentation job in `.github/workflows/ci.yml` tests both outputs and
+combines them on every CI run. A push to `main` additionally configures Pages
+and uploads the combined tree as the `github-pages` artifact; the dedicated
+deployment job publishes that artifact through the protected `github-pages`
+environment. CI never writes a generated `gh-pages` branch. The `book.toml`
 configuration tracks the custom domain and other mdBook options.

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -1,7 +1,7 @@
 [book]
 title = "ROUP Documentation"
 authors = ["Anjia Wang"]
-description = "Rust-based OpenMP/OpenACC Unified Parser - Safe, fast, and extensible"
+description = "Strict, safe Rust parser for typed OpenMP and OpenACC directive ASTs"
 language = "en"
 src = "src"
 

--- a/docs/book/src/building.md
+++ b/docs/book/src/building.md
@@ -5,6 +5,10 @@ ROUP is a Cargo workspace with two packages:
 - `roup`: the complete safe Rust parser (`rlib` only)
 - `roup-capi`: an optional C ABI (`rlib`, `staticlib`, and `cdylib`)
 
+Both packages use the Rust 2024 edition. The repository MSRV is Rust 1.88,
+which covers the complete required dependency and tooling graph, including the
+pinned mdBook 0.5.4 documentation tool.
+
 The root package is the default workspace member, so an ordinary build does
 not compile or link the ABI:
 

--- a/docs/book/src/line-continuations.md
+++ b/docs/book/src/line-continuations.md
@@ -27,10 +27,13 @@ with more directive text is a hard error.
 
 ## Fortran free and fixed forms
 
-Fortran continuations use a trailing `&`. A continuation line may repeat an
-OpenMP or OpenACC sentinel and may place `&` immediately after that sentinel.
-Only continuation syntax is removed; any source whitespace needed to separate
-tokens must be present in the input.
+Fortran continuations use a trailing `&`. A continuation line may repeat the
+sentinel for the configured dialect and may place `&` immediately after that
+sentinel. OpenMP accepts `!$omp`, OpenACC accepts `!$acc`, and both accept the
+standardized short `!$` form, case insensitively; using one dialect's long
+sentinel while parsing the other is a hard error. Only continuation syntax is
+removed, and any source whitespace needed to separate tokens must be present
+in the input.
 
 ```fortran
 !$omp target teams distribute &
@@ -38,10 +41,14 @@ tokens must be present in the input.
 !$omp& private(i, j)
 ```
 
-Fixed-form input accepts the configured standard sentinels, including `!$OMP`,
-`C$OMP`, and `*$OMP`, subject to fixed-form placement rules. A comment may
-follow a valid trailing `&`. Missing markers, text after a purported marker, or
-another directive line reached through ordinary whitespace are errors.
+The corresponding OpenACC form uses `!$acc` on each line. Fixed-form input
+accepts the configured standard sentinel family, including `!$OMP`, `C$OMP`,
+and `*$OMP`, the matching `ACC` forms, and their short `!$`, `C$`, and `*$`
+forms; leading horizontal whitespace is accepted before the sentinel. A
+comment may follow a valid trailing `&`.
+Missing markers, text after a purported marker, a conflicting-dialect
+sentinel, or another directive line reached through ordinary whitespace is an
+error.
 
 ## Spans
 
@@ -51,5 +58,6 @@ backslash and newline. Clause-name spans identify the exact source alias even
 when the semantic kind is canonicalized. Nested metadirective and construct
 selector directives use the same outer-source coordinate system.
 
-See `tests/openmp_line_continuations.rs` and
-`tests/source_span_regressions.rs` for executable examples.
+See `tests/openmp_line_continuations.rs`,
+`tests/openacc_line_continuations.rs`, and `tests/source_span_regressions.rs`
+for executable examples.

--- a/docs/book/src/openacc-support.md
+++ b/docs/book/src/openacc-support.md
@@ -33,6 +33,7 @@ features, and trailing input are hard errors. The parser never returns opaque
 payload text or retries with a permissive grammar.
 
 Public behavior is covered by `tests/openacc_public_api.rs`,
-`tests/openacc_directive_parameters.rs`, `tests/feature_availability.rs`, and
-the strict payload and error suites. C ABI and accparser adapter checks are
-separate consumers of the safe parser.
+`tests/openacc_directive_parameters.rs`,
+`tests/openacc_line_continuations.rs`, `tests/feature_availability.rs`, and the
+strict payload and error suites. C ABI and accparser adapter checks are separate
+consumers of the safe parser.

--- a/src/api.rs
+++ b/src/api.rs
@@ -14,21 +14,22 @@
 
 use crate::ast::{AccDirective, OmpDirective, RoupDirective};
 use crate::availability::{
-    openacc_compatible_versions, openacc_directive_availability, openmp_compatible_versions,
-    openmp_directive_availability, OPENACC_NONSTANDARD_SPELLINGS, OPENMP_NONSTANDARD_SPELLINGS,
+    OPENACC_NONSTANDARD_SPELLINGS, OPENMP_NONSTANDARD_SPELLINGS, openacc_compatible_versions,
+    openacc_directive_availability, openmp_compatible_versions, openmp_directive_availability,
 };
 use crate::diagnostic::{Diagnostic, DiagnosticCode};
 use crate::feature_availability::{
-    openacc_clause_syntax_availability, openacc_directive_parameter_availability,
-    openmp_clause_syntax_availability, openmp_directive_spelling_availability, FeatureAvailability,
+    FeatureAvailability, openacc_clause_syntax_availability,
+    openacc_directive_parameter_availability, openmp_clause_syntax_availability,
+    openmp_directive_spelling_availability,
 };
 use crate::ir::ParserConfig;
 use crate::lexer::Language as LexerLanguage;
 use crate::parser::{self, AstBuildError};
 use crate::source::Span;
 use crate::validation::{
-    validate_openacc, validate_openacc_with_facts, validate_openmp, validate_openmp_with_facts,
-    SemanticFacts,
+    SemanticFacts, validate_openacc, validate_openacc_with_facts, validate_openmp,
+    validate_openmp_with_facts,
 };
 use crate::version::{
     HostLanguageProfile, OpenAccVersion, OpenMpVersion, SourceForm, VersionPolicy, VersionSet,
@@ -731,9 +732,11 @@ mod tests {
         let c_parser = OpenMpConfig::new(c23(), SourceForm::Pragma)
             .expect("valid C configuration")
             .parser();
-        assert!(c_parser
-            .parse("#pragma omp cancellationpoint parallel")
-            .is_err());
+        assert!(
+            c_parser
+                .parse("#pragma omp cancellationpoint parallel")
+                .is_err()
+        );
     }
 
     #[test]

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -11,8 +11,8 @@ use std::fmt;
 
 use crate::host::TypeName;
 use crate::ir::{ClauseData, ClauseItem, Expression, Identifier, LValue, Variable};
-use crate::parser::directive_kind::DirectiveName;
 use crate::parser::ClauseName;
+use crate::parser::directive_kind::DirectiveName;
 use crate::source::Span;
 
 /// Re-export the typed OpenMP clause payload primitives from the semantic IR.
@@ -3600,31 +3600,37 @@ mod tests {
 
     #[test]
     fn clause_constructors_reject_empty_required_payloads() {
-        assert!(OmpClause::new(
-            OmpClauseKind::Nontemporal,
-            ClauseData::ItemList(Vec::new()),
-            None,
-            None,
-            Span::entire("nontemporal"),
-        )
-        .is_err());
-        assert!(OmpClause::new(
-            OmpClauseKind::Apply,
-            ClauseData::Apply {
-                loop_modifier: None,
-                applied_directives: Vec::new(),
-            },
-            None,
-            None,
-            Span::entire("apply"),
-        )
-        .is_err());
-        assert!(AccClause::new(
-            AccClauseKind::Private,
-            AccClausePayload::ItemList(Vec::new()),
-            None,
-            Span::entire("private"),
-        )
-        .is_err());
+        assert!(
+            OmpClause::new(
+                OmpClauseKind::Nontemporal,
+                ClauseData::ItemList(Vec::new()),
+                None,
+                None,
+                Span::entire("nontemporal"),
+            )
+            .is_err()
+        );
+        assert!(
+            OmpClause::new(
+                OmpClauseKind::Apply,
+                ClauseData::Apply {
+                    loop_modifier: None,
+                    applied_directives: Vec::new(),
+                },
+                None,
+                None,
+                Span::entire("apply"),
+            )
+            .is_err()
+        );
+        assert!(
+            AccClause::new(
+                AccClauseKind::Private,
+                AccClausePayload::ItemList(Vec::new()),
+                None,
+                Span::entire("private"),
+            )
+            .is_err()
+        );
     }
 }

--- a/src/availability.rs
+++ b/src/availability.rs
@@ -717,8 +717,10 @@ mod tests {
 
         let acc_end = openacc_directive_availability("end").expect("end is standardized");
         assert!(openacc_compatible_versions(acc_end, HostLanguage::Cpp).is_empty());
-        assert!(openacc_compatible_versions(acc_end, HostLanguage::Fortran)
-            .contains(OpenAccVersion::V1_0));
+        assert!(
+            openacc_compatible_versions(acc_end, HostLanguage::Fortran)
+                .contains(OpenAccVersion::V1_0)
+        );
     }
 
     #[test]
@@ -727,11 +729,15 @@ mod tests {
             openacc_directive_availability("serial").expect("serial is standardized");
 
         assert_eq!(availability.introduced(), OpenAccVersion::V2_6);
-        assert!(!availability
-            .version_interval()
-            .contains(OpenAccVersion::V2_5));
-        assert!(availability
-            .version_interval()
-            .contains(OpenAccVersion::V2_6));
+        assert!(
+            !availability
+                .version_interval()
+                .contains(OpenAccVersion::V2_5)
+        );
+        assert!(
+            availability
+                .version_interval()
+                .contains(OpenAccVersion::V2_6)
+        );
     }
 }

--- a/src/delimiter.rs
+++ b/src/delimiter.rs
@@ -51,7 +51,10 @@ impl fmt::Display for DelimiterError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::EmptyEntry { separator } => {
-                write!(formatter, "list separated by '{separator}' contains an empty entry")
+                write!(
+                    formatter,
+                    "list separated by '{separator}' contains an empty entry"
+                )
             }
             Self::UnterminatedQuote { quote, offset } => {
                 write!(formatter, "unclosed {quote} quote at byte {offset}")
@@ -60,7 +63,10 @@ impl fmt::Display for DelimiterError {
                 write!(formatter, "unclosed block comment at byte {offset}")
             }
             Self::UnmatchedClosing { delimiter, offset } => {
-                write!(formatter, "unmatched closing delimiter '{delimiter}' at byte {offset}")
+                write!(
+                    formatter,
+                    "unmatched closing delimiter '{delimiter}' at byte {offset}"
+                )
             }
             Self::MismatchedClosing {
                 opening,
@@ -456,12 +462,14 @@ mod tests {
         for source in ["\"unterminated", "a /* unterminated"] {
             assert!(split_top_level(source, ',', &[], CommentStyle::CLike).is_err());
         }
-        assert!(split_top_level(
-            "a, f(x]",
-            ',',
-            &[('(', ')'), ('[', ']')],
-            CommentStyle::Block,
-        )
-        .is_err());
+        assert!(
+            split_top_level(
+                "a, f(x]",
+                ',',
+                &[('(', ')'), ('[', ']')],
+                CommentStyle::Block,
+            )
+            .is_err()
+        );
     }
 }

--- a/src/host/lexer.rs
+++ b/src/host/lexer.rs
@@ -423,10 +423,12 @@ impl<'a> Lexer<'a> {
             return self.lex_identifier_or_keyword();
         }
 
-        if ch == '.' && self.language == HostLanguage::Fortran && !self.starts_with("..") {
-            if let Some(token) = self.lex_fortran_dotted()? {
-                return Ok(token);
-            }
+        if ch == '.'
+            && self.language == HostLanguage::Fortran
+            && !self.starts_with("..")
+            && let Some(token) = self.lex_fortran_dotted()?
+        {
+            return Ok(token);
         }
 
         self.lex_symbol()
@@ -518,7 +520,7 @@ impl<'a> Lexer<'a> {
             (HostLanguage::Cpp, "or_eq") => TokenKind::PipeEqual,
             (HostLanguage::Cpp, "xor_eq") => TokenKind::CaretEqual,
             _ if !self.allow_reserved_words && is_reserved_keyword(self.profile, text) => {
-                return Err(self.error(start, self.offset, LexErrorKind::UnsupportedKeyword))
+                return Err(self.error(start, self.offset, LexErrorKind::UnsupportedKeyword));
             }
             (HostLanguage::Fortran, _) => {
                 TokenKind::Identifier(Identifier::from_lexed(&text.to_lowercase()))
@@ -558,7 +560,7 @@ impl<'a> Lexer<'a> {
                     start,
                     end,
                     LexErrorKind::UnsupportedOperator("Fortran defined operator"),
-                ))
+                ));
             }
         };
         self.offset = end;
@@ -920,7 +922,7 @@ impl<'a> Lexer<'a> {
                     suffix_start,
                     self.offset,
                     LexErrorKind::InvalidNumber(self.source[start..self.offset].to_owned()),
-                ))
+                ));
             }
         };
         if matches!(suffix.width, CIntegerWidth::LongLong) && !self.supports_long_long_suffix() {
@@ -1016,10 +1018,10 @@ impl<'a> Lexer<'a> {
         ] {
             if self.starts_with(prefix) {
                 let after = self.offset + prefix.len();
-                if let Some(quote) = self.source[after..].chars().next() {
-                    if matches!(quote, '\'' | '"') {
-                        return Some((encoding, quote, prefix.len()));
-                    }
+                if let Some(quote) = self.source[after..].chars().next()
+                    && matches!(quote, '\'' | '"')
+                {
+                    return Some((encoding, quote, prefix.len()));
                 }
             }
         }
@@ -1146,7 +1148,7 @@ impl<'a> Lexer<'a> {
                     escape_start,
                     self.offset,
                     LexErrorKind::InvalidEscape(self.source[escape_start..self.offset].into()),
-                ))
+                ));
             }
         };
         let digits_start = self.offset;
@@ -1557,9 +1559,11 @@ mod tests {
         assert_eq!(integer.base, IntegerBase::Decimal);
         assert_eq!(integer.value, 12);
 
-        assert!(Lexer::new("0x10", HostLanguage::Fortran)
-            .tokenize()
-            .is_err());
+        assert!(
+            Lexer::new("0x10", HostLanguage::Fortran)
+                .tokenize()
+                .is_err()
+        );
         for source in ["1''2", "0x'1", "12uu", "12lz"] {
             assert!(
                 Lexer::new(source, HostLanguage::Cpp).tokenize().is_err(),

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -15,7 +15,7 @@ mod type_name;
 pub use ast::*;
 pub use lexer::{LexError, LexErrorKind, Lexer, Token, TokenKind};
 pub use parser::{
-    parse_expression, parse_expression_with_profile, ParseError, ParseErrorKind, Parser,
+    ParseError, ParseErrorKind, Parser, parse_expression, parse_expression_with_profile,
 };
 pub use render::CanonicalDisplay;
 pub use type_name::{Delimiter as TypeNameDelimiter, TypeName, TypeNameError};

--- a/src/host/render.rs
+++ b/src/host/render.rs
@@ -460,7 +460,7 @@ fn write_escaped_c_char(f: &mut fmt::Formatter<'_>, value: char, delimiter: char
 
 #[cfg(test)]
 mod tests {
-    use crate::host::{parse_expression, HostLanguage};
+    use crate::host::{HostLanguage, parse_expression};
 
     #[test]
     fn canonical_c_render_preserves_tree_semantics() {

--- a/src/host/type_name.rs
+++ b/src/host/type_name.rs
@@ -862,7 +862,11 @@ fn validate_fortran_selector_list(nodes: &[TypeSyntax<'_>]) -> bool {
     }
     split_on_commas(nodes).is_some_and(|selectors| {
         selectors.into_iter().all(|selector| {
-            if let [TypeSyntax::Token(TokenKind::Identifier(_)), TypeSyntax::Token(TokenKind::Equal), rest @ ..] = selector
+            if let [
+                TypeSyntax::Token(TokenKind::Identifier(_)),
+                TypeSyntax::Token(TokenKind::Equal),
+                rest @ ..,
+            ] = selector
             {
                 !rest.is_empty() && validate_fortran_selector_value(rest)
             } else {
@@ -1362,10 +1366,11 @@ mod tests {
 
         let cpp =
             TypeName::parse("std::vector<std::pair<int, 4>> const &", HostLanguage::Cpp).unwrap();
-        assert!(cpp
-            .tokens()
-            .iter()
-            .all(|token| !matches!(token, TokenKind::End)));
+        assert!(
+            cpp.tokens()
+                .iter()
+                .all(|token| !matches!(token, TokenKind::End))
+        );
         assert_eq!(
             cpp.to_string(),
             "std :: vector < std :: pair < int , 4 >> const &"

--- a/src/ir/lang/mod.rs
+++ b/src/ir/lang/mod.rs
@@ -70,10 +70,9 @@ fn classify_clause_item(expression: Expression) -> Result<ClauseItem, Conversion
         global: false,
         segments,
     }) = &expression.ast().kind
+        && segments.len() == 1
     {
-        if segments.len() == 1 {
-            return Ok(ClauseItem::Identifier(segments[0].clone()));
-        }
+        return Ok(ClauseItem::Identifier(segments[0].clone()));
     }
 
     if Variable::is_designator_expression(&expression) {

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -25,8 +25,8 @@ pub use clause::{
 };
 pub use error::ConversionError;
 pub use expression::{
-    BinaryOperator, Expression, ExpressionAst, ExpressionError, ExpressionKind, ParserConfig,
-    UnaryOperator, MAX_STRUCTURAL_NESTING_DEPTH,
+    BinaryOperator, Expression, ExpressionAst, ExpressionError, ExpressionKind,
+    MAX_STRUCTURAL_NESTING_DEPTH, ParserConfig, UnaryOperator,
 };
 pub use variable::{Identifier, IdentifierError, LValue, LValueError, Variable, VariableError};
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -619,15 +619,15 @@ pub fn collapse_line_continuations(input: &str) -> Cow<'_, str> {
                 idx = next;
                 continue;
             }
-        } else if bytes[idx] == b'&' {
-            if let Some(next) = skip_fortran_continuation(input, idx) {
-                changed = true;
-                // Remove only syntax that belongs to the continuation. Token
-                // separation must come from actual whitespace before the
-                // trailing marker or after the optional leading marker.
-                idx = next;
-                continue;
-            }
+        } else if bytes[idx] == b'&'
+            && let Some(next) = skip_fortran_continuation(input, idx)
+        {
+            changed = true;
+            // Remove only syntax that belongs to the continuation. Token
+            // separation must come from actual whitespace before the
+            // trailing marker or after the optional leading marker.
+            idx = next;
+            continue;
         }
 
         let next = next_char_boundary(input, idx);
@@ -915,24 +915,28 @@ mod tests {
         assert!(
             validate_logical_line("#pragma omp parallel\nprivate(x)", Language::C, "omp").is_err()
         );
-        assert!(validate_logical_line(
-            "!$omp parallel\n!$omp private(x)",
-            Language::FortranFree,
-            "omp",
-        )
-        .is_err());
+        assert!(
+            validate_logical_line(
+                "!$omp parallel\n!$omp private(x)",
+                Language::FortranFree,
+                "omp",
+            )
+            .is_err()
+        );
 
         assert!(validate_logical_line("#pragma omp parallel\n  ", Language::C, "omp").is_ok());
         assert!(
             validate_logical_line("#pragma omp parallel \\\n  private(x)", Language::C, "omp",)
                 .is_ok()
         );
-        assert!(validate_logical_line(
-            "!$omp parallel & ! comment\n!$omp& private(x)",
-            Language::FortranFree,
-            "omp",
-        )
-        .is_ok());
+        assert!(
+            validate_logical_line(
+                "!$omp parallel & ! comment\n!$omp& private(x)",
+                Language::FortranFree,
+                "omp",
+            )
+            .is_ok()
+        );
     }
 
     #[test]

--- a/src/parser/ast_builder.rs
+++ b/src/parser/ast_builder.rs
@@ -1,5 +1,5 @@
 use super::clause::LocatedClause;
-use super::clause::{lookup_clause_name, Clause, ClauseKind, ClauseName};
+use super::clause::{Clause, ClauseKind, ClauseName, lookup_clause_name};
 use super::directive::Directive;
 use super::semantic::{
     parse_acc_identifier_list, parse_clause_data, parse_directive_name_modifier,
@@ -25,8 +25,8 @@ use crate::ast::{
 };
 use crate::host::{ExprKind, Literal, QualifiedName, TokenKind, TypeName};
 use crate::ir::{
-    lang, ClauseData, ClauseItem, Expression, FirstprivateModifier, Identifier, LValue,
-    ParserConfig, ProcBind, Variable,
+    ClauseData, ClauseItem, Expression, FirstprivateModifier, Identifier, LValue, ParserConfig,
+    ProcBind, Variable, lang,
 };
 use crate::lexer::{LogicalSource, LogicalSourceError};
 use crate::version::{HostLanguage, OpenMpVersion, VersionPolicy};
@@ -296,7 +296,7 @@ fn build_omp_directive_parameter(
                 _ => {
                     return Err(AstBuildError::ParseFailure(format!(
                         "unknown cancel construct: {raw_construct}"
-                    )))
+                    )));
                 }
             };
             return Ok(Some(OmpDirectiveParameter::Construct(construct)));
@@ -557,10 +557,10 @@ fn parse_omp_function_name(
     source: &str,
     parser_config: &ParserConfig,
 ) -> Result<OmpFunctionName, AstBuildError> {
-    if let Ok(expression) = Expression::new(source, parser_config) {
-        if let ExprKind::Name(name) = &expression.ast().kind {
-            return Ok(OmpFunctionName::Name(name.clone()));
-        }
+    if let Ok(expression) = Expression::new(source, parser_config)
+        && let ExprKind::Name(name) = &expression.ast().kind
+    {
+        return Ok(OmpFunctionName::Name(name.clone()));
     }
 
     if matches!(parser_config.host_language(), HostLanguage::Cpp) {
@@ -848,17 +848,17 @@ fn parse_openmp_id_expression(
     parser_config: &ParserConfig,
     context: &str,
 ) -> Result<OmpIdExpression, AstBuildError> {
-    if let Ok(expression) = Expression::new(source, parser_config) {
-        if let crate::host::ExprKind::Name(name) = &expression.ast().kind {
-            if parser_config.host_language() != HostLanguage::Cpp
-                && (name.global || name.segments.len() != 1)
-            {
-                return Err(AstBuildError::ParseFailure(format!(
-                    "{context} must be an unqualified base-language identifier"
-                )));
-            }
-            return Ok(OmpIdExpression::Name(name.clone()));
+    if let Ok(expression) = Expression::new(source, parser_config)
+        && let crate::host::ExprKind::Name(name) = &expression.ast().kind
+    {
+        if parser_config.host_language() != HostLanguage::Cpp
+            && (name.global || name.segments.len() != 1)
+        {
+            return Err(AstBuildError::ParseFailure(format!(
+                "{context} must be an unqualified base-language identifier"
+            )));
         }
+        return Ok(OmpIdExpression::Name(name.clone()));
     }
 
     if parser_config.host_language() == HostLanguage::Cpp {
@@ -939,12 +939,11 @@ fn parse_cpp_operator_qualifier(
     source: &str,
     parser_config: &ParserConfig,
 ) -> Result<OmpCppOperatorQualifier, AstBuildError> {
-    if let Ok(expression) = Expression::new(source, parser_config) {
-        if let ExprKind::Name(name) = &expression.ast().kind {
-            if !name.global {
-                return Ok(OmpCppOperatorQualifier::Name(name.clone()));
-            }
-        }
+    if let Ok(expression) = Expression::new(source, parser_config)
+        && let ExprKind::Name(name) = &expression.ast().kind
+        && !name.global
+    {
+        return Ok(OmpCppOperatorQualifier::Name(name.clone()));
     }
 
     let syntax = TypeName::parse_with_profile(source, parser_config.profile())?;
@@ -1138,7 +1137,7 @@ fn unique_reduction_clause_argument<'a>(
         _ => {
             return Err(AstBuildError::ParseFailure(
                 "internal declare-reduction clause classification failure".to_string(),
-            ))
+            ));
         }
     };
     let mut result = None;
@@ -1733,19 +1732,19 @@ fn build_acc_directive_parameter(
         )?)));
     }
 
-    if kind == AccDirectiveKind::Routine {
-        if let Some(param) = directive.parameter.as_ref() {
-            let inner = parse_parenthesized_directive_parameter(param, "OpenACC routine")?.trim();
-            if inner.is_empty() {
-                return Err(AstBuildError::ParseFailure(
-                    "OpenACC routine parentheses require a routine name".to_string(),
-                ));
-            }
-            let ident = Identifier::new(inner)?;
-            return Ok(Some(AccDirectiveParameter::Routine(
-                AccRoutineDirective::new(ident),
-            )));
+    if kind == AccDirectiveKind::Routine
+        && let Some(param) = directive.parameter.as_ref()
+    {
+        let inner = parse_parenthesized_directive_parameter(param, "OpenACC routine")?.trim();
+        if inner.is_empty() {
+            return Err(AstBuildError::ParseFailure(
+                "OpenACC routine parentheses require a routine name".to_string(),
+            ));
         }
+        let ident = Identifier::new(inner)?;
+        return Ok(Some(AccDirectiveParameter::Routine(
+            AccRoutineDirective::new(ident),
+        )));
     }
 
     if kind == AccDirectiveKind::End {
@@ -2019,12 +2018,10 @@ fn parse_omp_clause_semantics(
     }
     if omp_universal_modifier_syntax_is_enabled(clause_name, parser_config)
         && matches!(clause_name, ClauseName::Firstprivate)
-    {
-        if let Some((payload, modifier)) =
+        && let Some((payload, modifier)) =
             parse_firstprivate_with_universal_modifier(clause, directive_kind, parser_config)?
-        {
-            return Ok((payload, Some(modifier)));
-        }
+    {
+        return Ok((payload, Some(modifier)));
     }
 
     if omp_universal_modifier_syntax_is_enabled(clause_name, parser_config) {
@@ -2034,39 +2031,33 @@ fn parse_omp_clause_semantics(
             }
             _ => None,
         };
-        if let Some(content) = content {
-            if let Some((candidate, argument)) = lang::split_once_top_level(content, ':')? {
-                if let Ok(parsed) = parse_directive_name_modifier(candidate.trim(), parser_config) {
-                    if crate::validation::omp_modifier_names_directive_or_constituent(
-                        directive_kind,
-                        parsed,
-                    ) {
-                        let view = borrowed_clause_argument_view(clause, argument);
-                        let payload = match &view.kind {
-                            ClauseKind::FlushMemoryOrderArgument(content) => {
-                                let content = content.as_ref().trim();
-                                if content.is_empty() {
-                                    return Err(AstBuildError::ClauseConversion(
-                                        "use_semantics requires a non-empty expression".to_string(),
-                                    ));
-                                }
-                                ClauseData::MemoryOrder {
-                                    order: parse_memory_order(clause.name.as_ref(), parser_config)
-                                        .map_err(|error| {
-                                            AstBuildError::ClauseConversion(error.to_string())
-                                        })?,
-                                    use_semantics: Some(Expression::new(content, parser_config)?),
-                                }
-                            }
-                            _ => parse_clause_data(&view, directive_kind, parser_config, source)
-                                .map_err(|error| {
-                                    AstBuildError::ClauseConversion(error.to_string())
-                                })?,
-                        };
-                        return Ok((payload, Some(parsed)));
+        if let Some(content) = content
+            && let Some((candidate, argument)) = lang::split_once_top_level(content, ':')?
+            && let Ok(parsed) = parse_directive_name_modifier(candidate.trim(), parser_config)
+            && crate::validation::omp_modifier_names_directive_or_constituent(
+                directive_kind,
+                parsed,
+            )
+        {
+            let view = borrowed_clause_argument_view(clause, argument);
+            let payload = match &view.kind {
+                ClauseKind::FlushMemoryOrderArgument(content) => {
+                    let content = content.as_ref().trim();
+                    if content.is_empty() {
+                        return Err(AstBuildError::ClauseConversion(
+                            "use_semantics requires a non-empty expression".to_string(),
+                        ));
+                    }
+                    ClauseData::MemoryOrder {
+                        order: parse_memory_order(clause.name.as_ref(), parser_config)
+                            .map_err(|error| AstBuildError::ClauseConversion(error.to_string()))?,
+                        use_semantics: Some(Expression::new(content, parser_config)?),
                     }
                 }
-            }
+                _ => parse_clause_data(&view, directive_kind, parser_config, source)
+                    .map_err(|error| AstBuildError::ClauseConversion(error.to_string()))?,
+            };
+            return Ok((payload, Some(parsed)));
         }
     }
 
@@ -2139,7 +2130,7 @@ fn convert_clause_to_omp(
                     _ => {
                         return Err(AstBuildError::ClauseConversion(
                             "invalid historical doacross payload".to_string(),
-                        ))
+                        ));
                     }
                 },
             ),
@@ -2175,19 +2166,19 @@ fn convert_clause_to_omp(
     };
     let kind = OmpClauseKind::try_from(canonical_name)
         .map_err(|_| AstBuildError::UnsupportedClause(clause.name.as_ref().to_string()))?;
-    if let Some(modifier) = directive_name_modifier {
-        if !crate::validation::omp_clause_applies_to_named_constituent(
+    if let Some(modifier) = directive_name_modifier
+        && !crate::validation::omp_clause_applies_to_named_constituent(
             directive_kind,
             modifier,
             kind,
-        ) {
-            return Err(AstBuildError::ClauseConversion(format!(
-                "clause {} does not apply to named constituent {} of {}",
-                kind.as_str(),
-                modifier.as_str(),
-                directive_kind.as_str()
-            )));
-        }
+        )
+    {
+        return Err(AstBuildError::ClauseConversion(format!(
+            "clause {} does not apply to named constituent {} of {}",
+            kind.as_str(),
+            modifier.as_str(),
+            directive_kind.as_str()
+        )));
     }
 
     let span = source.span_of(clause.name_source())?;
@@ -2304,7 +2295,7 @@ fn build_acc_default_clause(
         _ => {
             return Err(AstBuildError::ClauseConversion(
                 "OpenACC default clause requires one parenthesized value".to_string(),
-            ))
+            ));
         }
     };
 
@@ -2317,12 +2308,12 @@ fn build_acc_default_clause(
             "" => {
                 return Err(AstBuildError::ClauseConversion(
                     "OpenACC default clause requires 'none' or 'present'".to_string(),
-                ))
+                ));
             }
             other => {
                 return Err(AstBuildError::ClauseConversion(format!(
                     "unknown OpenACC default value: {other}"
-                )))
+                )));
             }
         }
     };
@@ -2348,7 +2339,7 @@ fn build_acc_collapse_clause(
             return Err(AstBuildError::ClauseConversion(format!(
                 "unknown OpenACC collapse modifier: {}",
                 modifier.trim()
-            )))
+            )));
         }
         None => (false, text),
     };
@@ -2480,7 +2471,7 @@ fn build_acc_copy_clause(
         other => {
             return Err(AstBuildError::UnsupportedClause(format!(
                 "unknown OpenACC copy clause keyword: {other}"
-            )))
+            )));
         }
     };
 
@@ -2512,7 +2503,7 @@ fn build_acc_copy_clause(
         _ => {
             return Err(AstBuildError::UnsupportedClause(
                 "copy clause requires a variable list".to_string(),
-            ))
+            ));
         }
     };
 
@@ -2531,7 +2522,7 @@ fn build_acc_create_clause(
         other => {
             return Err(AstBuildError::UnsupportedClause(format!(
                 "unknown OpenACC create clause keyword: {other}"
-            )))
+            )));
         }
     };
 
@@ -2544,7 +2535,7 @@ fn build_acc_create_clause(
         _ => {
             return Err(AstBuildError::UnsupportedClause(
                 "create clause requires a variable list".to_string(),
-            ))
+            ));
         }
     };
 
@@ -2596,12 +2587,12 @@ fn parse_acc_data_clause_content(
                     "" => {
                         return Err(AstBuildError::ClauseConversion(
                             "OpenACC data modifier list contains an empty entry".to_string(),
-                        ))
+                        ));
                     }
                     other => {
                         return Err(AstBuildError::ClauseConversion(format!(
                             "unknown OpenACC data modifier: {other}"
-                        )))
+                        )));
                     }
                 }
             };
@@ -2726,12 +2717,12 @@ fn build_acc_wait_clause(
             return Ok(AccClausePayload::Wait(AccWaitClause::new(
                 None,
                 Vec::new(),
-            )?))
+            )?));
         }
         _ => {
             return Err(AstBuildError::ClauseConversion(
                 "OpenACC wait clause has an invalid payload shape".to_string(),
-            ))
+            ));
         }
     };
     if content.is_empty() {
@@ -2786,7 +2777,7 @@ fn build_acc_vector_clause(
         _ => {
             return Err(AstBuildError::ClauseConversion(
                 "OpenACC vector clause has an invalid payload shape".to_string(),
-            ))
+            ));
         }
     };
     Ok(AccClausePayload::Vector(vector))
@@ -2829,7 +2820,7 @@ fn build_acc_worker_clause(
         _ => {
             return Err(AstBuildError::ClauseConversion(
                 "OpenACC worker clause has an invalid payload shape".to_string(),
-            ))
+            ));
         }
     };
     Ok(AccClausePayload::Worker(worker))
@@ -2844,7 +2835,7 @@ fn build_acc_bind_clause(
         _ => {
             return Err(AstBuildError::ClauseConversion(
                 "OpenACC bind clause requires a parenthesized name or string literal".to_string(),
-            ))
+            ));
         }
     };
     if content.is_empty() {
@@ -2864,7 +2855,7 @@ fn build_acc_bind_clause(
         _ => {
             return Err(AstBuildError::ClauseConversion(
                 "OpenACC bind target must be one host-language name or string literal".to_string(),
-            ))
+            ));
         }
     };
     Ok(AccClausePayload::Bind(target))
@@ -2950,7 +2941,7 @@ fn build_acc_gang_clause(
         _ => {
             return Err(AstBuildError::ClauseConversion(
                 "OpenACC gang clause has an invalid payload shape".to_string(),
-            ))
+            ));
         }
     };
     Ok(AccClausePayload::Gang(AccGangClause::new(arguments)?))
@@ -2977,7 +2968,7 @@ fn build_acc_device_type_clause(
         _ => {
             return Err(AstBuildError::ClauseConversion(
                 "OpenACC device_type clause requires a parenthesized name list".to_string(),
-            ))
+            ));
         }
     };
     if raw_values.is_empty() || raw_values.iter().any(|value| value.trim().is_empty()) {
@@ -3091,7 +3082,7 @@ fn require_acc_item_list(
             return Err(AstBuildError::ClauseConversion(format!(
                 "OpenACC {} clause requires a parenthesized variable list",
                 clause.name.as_ref()
-            )))
+            )));
         }
     };
 

--- a/src/parser/directive.rs
+++ b/src/parser/directive.rs
@@ -4,7 +4,7 @@ use std::{
     ops::Deref,
 };
 
-use nom::{error::ErrorKind, IResult};
+use nom::{IResult, error::ErrorKind};
 
 use super::clause::{ClauseRegistry, LocatedClause};
 use crate::parser::directive_kind::DirectiveName;

--- a/src/parser/directive_kind.rs
+++ b/src/parser/directive_kind.rs
@@ -734,14 +734,14 @@ pub fn lookup_directive_name(name: &str) -> DirectiveName {
     // Preserve underscore spelling in begin/end declare_target even when
     // whitespace separates the tokens (e.g., "begin declare_target").
     let mut parts = trimmed.split_whitespace();
-    if let (Some(first), Some(second), None) = (parts.next(), parts.next(), parts.next()) {
-        if second.eq_ignore_ascii_case("declare_target") {
-            if first.eq_ignore_ascii_case("begin") {
-                return DirectiveName::BeginDeclareTargetUnderscore;
-            }
-            if first.eq_ignore_ascii_case("end") {
-                return DirectiveName::EndDeclareTargetUnderscore;
-            }
+    if let (Some(first), Some(second), None) = (parts.next(), parts.next(), parts.next())
+        && second.eq_ignore_ascii_case("declare_target")
+    {
+        if first.eq_ignore_ascii_case("begin") {
+            return DirectiveName::BeginDeclareTargetUnderscore;
+        }
+        if first.eq_ignore_ascii_case("end") {
+            return DirectiveName::EndDeclareTargetUnderscore;
         }
     }
     let normalized = normalize_directive_key(name);

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11,8 +11,8 @@ pub(crate) mod semantic;
 pub(crate) use ast_builder::AstBuildError;
 
 pub(crate) use clause::{
-    lookup_clause_name, Clause, ClauseKind, ClauseName, ClauseRegistry, ClauseRegistryBuilder,
-    ClauseRule,
+    Clause, ClauseKind, ClauseName, ClauseRegistry, ClauseRegistryBuilder, ClauseRule,
+    lookup_clause_name,
 };
 pub(crate) use directive::{
     Directive, DirectiveRegistry, DirectiveRegistryBuilder, LocatedDirective,

--- a/src/parser/openmp.rs
+++ b/src/parser/openmp.rs
@@ -3,7 +3,7 @@ use super::{
     Parser,
 };
 use crate::parser::clause::{
-    parse_variable_list, ClauseKind, ReductionModifier, ReductionOperator,
+    ClauseKind, ReductionModifier, ReductionOperator, parse_variable_list,
 };
 
 const OPENMP_DEFAULT_CLAUSE_RULE: ClauseRule = ClauseRule::Unsupported;

--- a/src/parser/semantic.rs
+++ b/src/parser/semantic.rs
@@ -16,7 +16,7 @@ use crate::ast::{
 };
 use crate::host::{BinaryOp, ExprKind, HostLanguage, Literal, UnaryOp};
 use crate::ir::{
-    lang, AdjustArgsModifier, AllocateSourceSyntax, AtKind, AtomicOp, BindModifier, ClauseData,
+    AdjustArgsModifier, AllocateSourceSyntax, AtKind, AtomicOp, BindModifier, ClauseData,
     ClauseItem, ConversionError, DefaultKind, DefaultmapBehavior, DefaultmapCategory,
     DependIterator, DependType, DepobjUpdateDependence, DeviceModifier, DeviceType, DoacrossType,
     Expression, ExtendedAtomicKind, FirstprivateModifier, GrainsizeModifier, Identifier, LValue,
@@ -28,12 +28,12 @@ use crate::ir::{
     OmpParameterRange, OmpPreferenceSelector, OmpPreferenceSpecification, OrderKind, OrderModifier,
     OriginalSharing, ParserConfig, ProcBind, ReductionModifier, RequireModifier, ScanClauseMode,
     ScheduleKind, ScheduleModifier, SeverityKind, ThreadsetKind, UsesAllocatorBuiltin,
-    UsesAllocatorKind, UsesAllocatorSourceSyntax, UsesAllocatorSpec, Variable,
+    UsesAllocatorKind, UsesAllocatorSourceSyntax, UsesAllocatorSpec, Variable, lang,
 };
 use crate::lexer::{Language as LexerLanguage, LogicalSource};
 use crate::parser::clause::ReductionOperator as ParserReductionOperator;
 use crate::parser::clause::{lookup_clause_name, parse_variable_list};
-use crate::parser::directive_kind::{lookup_directive_name, DirectiveName};
+use crate::parser::directive_kind::{DirectiveName, lookup_directive_name};
 use crate::parser::{Clause, ClauseKind, ClauseName};
 
 /// Return a canonical payload keyword only for a case-insensitive host
@@ -245,7 +245,7 @@ fn convert_parser_reduction_operator(
             return Err(ConversionError::InvalidClauseSyntax(
                 "reduction identifier is not standardized for the configured host language"
                     .to_string(),
-            ))
+            ));
         }
         ParserReductionOperator::UserDefined => {
             let identifier = user_identifier
@@ -330,7 +330,7 @@ fn parse_original_reduction_modifier(
             return Err(ConversionError::InvalidClauseSyntax(format!(
                 "unknown original sharing value: {}",
                 value.trim()
-            )))
+            )));
         }
     };
     Ok(ReductionModifier::Original(sharing))
@@ -385,7 +385,7 @@ pub fn parse_schedule_clause(
                 _ => {
                     return Err(ConversionError::InvalidClauseSyntax(format!(
                         "Unknown schedule modifier: {raw}"
-                    )))
+                    )));
                 }
             };
 
@@ -444,7 +444,7 @@ pub fn parse_schedule_clause(
         Some(value) if value.trim().is_empty() => {
             return Err(ConversionError::InvalidClauseSyntax(
                 "schedule chunk expression must not be empty".to_string(),
-            ))
+            ));
         }
         Some(value) => Some(Expression::new(value.trim(), config)?),
         None => None,
@@ -578,15 +578,15 @@ pub fn parse_map_clause(
                     _ => {
                         return Err(ConversionError::InvalidClauseSyntax(format!(
                             "Unknown map modifier or type: {token}"
-                        )))
+                        )));
                     }
                 };
-                if let Some(parsed_type) = parsed_type {
-                    if map_type.replace(parsed_type).is_some() {
-                        return Err(ConversionError::InvalidClauseSyntax(
-                            "map clause specifies more than one map type".to_string(),
-                        ));
-                    }
+                if let Some(parsed_type) = parsed_type
+                    && map_type.replace(parsed_type).is_some()
+                {
+                    return Err(ConversionError::InvalidClauseSyntax(
+                        "map clause specifies more than one map type".to_string(),
+                    ));
                 }
             }
             if modifiers.contains(&MapModifier::Delete) && map_type.is_none() {
@@ -958,7 +958,7 @@ fn parse_declare_target_enter_clause(
             return Err(ConversionError::InvalidClauseSyntax(format!(
                 "unknown declare-target enter modifier: {}",
                 modifier.trim()
-            )))
+            )));
         }
         None => (false, content.trim()),
     };
@@ -1281,7 +1281,7 @@ fn parse_apply_loop_modifier(
         _ => {
             return Err(ConversionError::InvalidClauseSyntax(format!(
                 "unknown apply loop modifier: {keyword_source}"
-            )))
+            )));
         }
     };
     let indices = indices_source
@@ -1299,7 +1299,7 @@ pub(crate) fn parse_at_clause(
     kind: &ClauseKind<'_>,
     config: &ParserConfig,
 ) -> Result<ClauseData, ConversionError> {
-    if let ClauseKind::Parenthesized(ref content) = kind {
+    if let ClauseKind::Parenthesized(content) = kind {
         let value = content.as_ref().trim();
         let keyword = payload_keyword(value, config);
         let at_kind = match keyword.as_ref() {
@@ -1308,12 +1308,12 @@ pub(crate) fn parse_at_clause(
             "" => {
                 return Err(ConversionError::InvalidClauseSyntax(
                     "at clause requires a value".to_string(),
-                ))
+                ));
             }
             _ => {
                 return Err(ConversionError::InvalidClauseSyntax(format!(
                     "Unknown at clause value: {value}"
-                )))
+                )));
             }
         };
         Ok(ClauseData::At(at_kind))
@@ -1459,7 +1459,7 @@ fn parse_depobj_init_clause(
         other => {
             return Err(ConversionError::InvalidClauseSyntax(format!(
                 "unknown depobj init dependence type: {other}"
-            )))
+            )));
         }
     };
     let locator_source = extract_paren_arg(depinfo_source)?.ok_or_else(|| {
@@ -1852,7 +1852,7 @@ pub(crate) fn parse_defaultmap_clause(
     kind: &ClauseKind<'_>,
     config: &ParserConfig,
 ) -> Result<ClauseData, ConversionError> {
-    if let ClauseKind::Parenthesized(ref content) = kind {
+    if let ClauseKind::Parenthesized(content) = kind {
         let text = content.as_ref().trim();
         if text.is_empty() {
             return Err(ConversionError::InvalidClauseSyntax(
@@ -1872,7 +1872,7 @@ pub(crate) fn parse_defaultmap_clause(
             Some("") => {
                 return Err(ConversionError::InvalidClauseSyntax(
                     "defaultmap category must not be empty".to_string(),
-                ))
+                ));
             }
             Some(value) => Some(parse_defaultmap_category(value, config)?),
             None => None,
@@ -1900,7 +1900,7 @@ pub(crate) fn parse_metadirective_selector(
             other => {
                 return Err(ConversionError::InvalidClauseSyntax(format!(
                     "{other:?} is not a metadirective selector clause"
-                )))
+                )));
             }
         };
         let selector = parse_selector_content(raw, config, mode, source)?;
@@ -1951,12 +1951,12 @@ fn parse_selector_content(
         {
             return Err(ConversionError::InvalidClauseSyntax(
                 "when clause requires a directive variant after ':'".to_string(),
-            ))
+            ));
         }
         SelectorClauseMode::Match if nested_directive_part.is_some() => {
             return Err(ConversionError::InvalidClauseSyntax(
                 "match clause does not accept a nested directive".to_string(),
-            ))
+            ));
         }
         _ => {}
     }
@@ -2073,7 +2073,7 @@ fn parse_selector_content(
             _ => {
                 return Err(ConversionError::InvalidClauseSyntax(format!(
                     "unknown metadirective selector key: {raw_key}"
-                )))
+                )));
             }
         }
     }
@@ -2081,10 +2081,10 @@ fn parse_selector_content(
     // Nested directive after colon (parse into nested_directive AST)
     if let Some(nested) = nested_directive_part {
         let nested_trimmed = nested.trim();
-        if !nested_trimmed.is_empty() {
-            if let Some(dir) = parse_nested_directive(nested_trimmed, config, source)? {
-                nested_directive = Some(Box::new(dir));
-            }
+        if !nested_trimmed.is_empty()
+            && let Some(dir) = parse_nested_directive(nested_trimmed, config, source)?
+        {
+            nested_directive = Some(Box::new(dir));
         }
     }
 
@@ -2406,7 +2406,7 @@ fn parse_selector_requirement(
         _ => {
             return Err(ConversionError::InvalidClauseSyntax(format!(
                 "unknown requires selector clause property: {source}"
-            )))
+            )));
         }
     };
     let required = argument
@@ -2824,7 +2824,7 @@ fn parse_defaultmap_behavior(
         _ => {
             return Err(ConversionError::InvalidClauseSyntax(format!(
                 "Unknown defaultmap behavior: {raw}"
-            )))
+            )));
         }
     };
     Ok(behavior)
@@ -2845,7 +2845,7 @@ fn parse_defaultmap_category(
         _ => {
             return Err(ConversionError::InvalidClauseSyntax(format!(
                 "Unknown defaultmap category: {raw}"
-            )))
+            )));
         }
     };
     Ok(category)
@@ -3026,7 +3026,7 @@ fn parse_omp_memory_space(
         _ => {
             return Err(ConversionError::InvalidClauseSyntax(format!(
                 "unknown predefined OpenMP memory space: {source}"
-            )))
+            )));
         }
     })
 }
@@ -3053,7 +3053,7 @@ pub(crate) fn parse_device_clause(
     kind: &ClauseKind<'_>,
     config: &ParserConfig,
 ) -> Result<ClauseData, ConversionError> {
-    if let ClauseKind::Parenthesized(ref content) = kind {
+    if let ClauseKind::Parenthesized(content) = kind {
         let text = content.as_ref().trim();
         let (modifier, expr_text) = match lang::split_once_top_level(text, ':')? {
             Some((name, rest)) if payload_keyword_eq(name.trim(), "ancestor", config) => {
@@ -3066,7 +3066,7 @@ pub(crate) fn parse_device_clause(
                 return Err(ConversionError::InvalidClauseSyntax(format!(
                     "unknown device modifier: {}",
                     name.trim()
-                )))
+                )));
             }
             None => (None, text),
         };
@@ -3244,7 +3244,7 @@ pub(crate) fn parse_scan_clause(
         _ => {
             return Err(ConversionError::InvalidClauseSyntax(
                 "scan clause requires a variable list".to_string(),
-            ))
+            ));
         }
     };
 
@@ -3529,7 +3529,7 @@ fn parse_depend_objects(
                 ClauseItem::FortranCommonBlock(_) | ClauseItem::Expression(_) => {
                     return Err(ConversionError::InvalidClauseSyntax(
                         "depend(depobj: ...) accepts only depend-object variables".to_string(),
-                    ))
+                    ));
                 }
             };
             if object.has_array_section() {
@@ -3595,7 +3595,7 @@ fn parse_doacross_vector_item(
                     return Err(ConversionError::InvalidClauseSyntax(
                         "doacross vector offsets must be non-negative constant integers"
                             .to_string(),
-                    ))
+                    ));
                 }
                 ObviousIntegerValue::Unknown | ObviousIntegerValue::NonNegative(_) => {}
             }
@@ -3609,7 +3609,7 @@ fn parse_doacross_vector_item(
         _ => {
             return Err(ConversionError::InvalidClauseSyntax(
                 "doacross vector entries must have the form variable[+/-offset]".to_string(),
-            ))
+            ));
         }
     };
     if payload_keyword_eq(variable.as_str(), "omp_cur_iteration", config) {
@@ -3660,22 +3660,20 @@ fn parse_doacross_iteration(
             left,
             right,
         } = &unparenthesized_expression(expression.ast()).kind
-        {
-            if simple_expression_identifier(left)
+            && simple_expression_identifier(left)
                 .is_some_and(|name| payload_keyword_eq(name.as_str(), "omp_cur_iteration", config))
-                && matches!(
-                    obvious_integer_value(&expression.subtree(right)),
-                    ObviousIntegerValue::NonNegative(1)
-                )
-            {
-                return if kind == DoacrossType::Sink {
-                    Ok(OmpDoacrossIteration::PreviousCurrent)
-                } else {
-                    Err(ConversionError::InvalidClauseSyntax(
-                        "source may specify only omp_cur_iteration".to_string(),
-                    ))
-                };
-            }
+            && matches!(
+                obvious_integer_value(&expression.subtree(right)),
+                ObviousIntegerValue::NonNegative(1)
+            )
+        {
+            return if kind == DoacrossType::Sink {
+                Ok(OmpDoacrossIteration::PreviousCurrent)
+            } else {
+                Err(ConversionError::InvalidClauseSyntax(
+                    "source may specify only omp_cur_iteration".to_string(),
+                ))
+            };
         }
     }
 
@@ -3791,7 +3789,7 @@ fn parse_doacross_clause(
         _ => {
             return Err(ConversionError::InvalidClauseSyntax(format!(
                 "unknown doacross dependence type: {kind_source}"
-            )))
+            )));
         }
     };
     Ok(ClauseData::Doacross {
@@ -4424,19 +4422,16 @@ fn parse_nonrecursive_clause_data<'a>(
                         ));
                     }
                 }
-                if let Some(lower) = lower_bound.as_ref() {
-                    if let (
+                if let Some(lower) = lower_bound.as_ref()
+                    && let (
                         ObviousIntegerValue::NonNegative(lower),
                         ObviousIntegerValue::NonNegative(upper),
                     ) = (obvious_integer_value(lower), obvious_integer_value(&upper_bound))
-                    {
-                        if lower > upper {
-                            return Err(ConversionError::InvalidClauseSyntax(
-                                "num_teams lower bound must not exceed its upper bound"
-                                    .to_string(),
-                            ));
-                        }
-                    }
+                    && lower > upper
+                {
+                    return Err(ConversionError::InvalidClauseSyntax(
+                        "num_teams lower bound must not exceed its upper bound".to_string(),
+                    ));
                 }
                 Ok(ClauseData::NumTeams {
                     lower_bound,

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1164,19 +1164,18 @@ fn validate_openmp_directive_specific_clause(
             }
         }
         ClauseData::Depend { dependence, .. } => {
-            if let crate::ir::OmpDependence::Locators { kind, locators } = dependence {
-                if locators.contains(&OmpLocator::AllMemory)
-                    && (!matches!(
-                        kind,
-                        crate::ir::DependType::Out | crate::ir::DependType::Inout
-                    ) || locators.len() != 1)
-                {
-                    return Err(Diagnostic::new(
-                        DiagnosticCode::InvalidClause,
-                        span,
-                        "omp_all_memory must be the only locator and use out or inout dependence",
-                    ));
-                }
+            if let crate::ir::OmpDependence::Locators { kind, locators } = dependence
+                && locators.contains(&OmpLocator::AllMemory)
+                && (!matches!(
+                    kind,
+                    crate::ir::DependType::Out | crate::ir::DependType::Inout
+                ) || locators.len() != 1)
+            {
+                return Err(Diagnostic::new(
+                    DiagnosticCode::InvalidClause,
+                    span,
+                    "omp_all_memory must be the only locator and use out or inout dependence",
+                ));
             }
             Ok(())
         }
@@ -1352,14 +1351,14 @@ fn validate_openmp_apply_clause(
                     modifier.kind,
                     directive.kind()
                 ),
-            ))
+            ));
         }
         None if !has_default => {
             return Err(Diagnostic::new(
                 DiagnosticCode::MissingRequiredClause,
                 span,
                 format!("apply on {:?} requires a loop modifier", directive.kind()),
-            ))
+            ));
         }
         Some(_) | None => {}
     }
@@ -1716,14 +1715,14 @@ fn require_openmp_semantic_facts(
                     DiagnosticCode::MissingContext,
                     span,
                     format!("missing required association fact: {association:?}"),
-                ))
+                ));
             }
             Some(false) => {
                 return Err(Diagnostic::new(
                     DiagnosticCode::InvalidAssociation,
                     span,
                     format!("invalid directive association: {association:?}"),
-                ))
+                ));
             }
             Some(true) => {}
         }
@@ -2464,14 +2463,14 @@ fn validate_openmp_obvious_scalar_constraints(
             }
         }
         ClauseData::Align { alignment } => {
-            if let Some(value) = reject_obvious_nonpositive(alignment, span, "align")? {
-                if !value.is_power_of_two() {
-                    return Err(Diagnostic::new(
-                        DiagnosticCode::InvalidClause,
-                        span,
-                        "align requires a power-of-two constant integer value",
-                    ));
-                }
+            if let Some(value) = reject_obvious_nonpositive(alignment, span, "align")?
+                && !value.is_power_of_two()
+            {
+                return Err(Diagnostic::new(
+                    DiagnosticCode::InvalidClause,
+                    span,
+                    "align requires a power-of-two constant integer value",
+                ));
             }
         }
         ClauseData::Allocate {
@@ -2479,14 +2478,13 @@ fn validate_openmp_obvious_scalar_constraints(
             ..
         } => {
             if let Some(value) = reject_obvious_nonpositive(alignment, span, "allocate alignment")?
+                && !value.is_power_of_two()
             {
-                if !value.is_power_of_two() {
-                    return Err(Diagnostic::new(
-                        DiagnosticCode::InvalidClause,
-                        span,
-                        "allocate alignment requires a power-of-two constant integer value",
-                    ));
-                }
+                return Err(Diagnostic::new(
+                    DiagnosticCode::InvalidClause,
+                    span,
+                    "allocate alignment requires a power-of-two constant integer value",
+                ));
             }
         }
         ClauseData::Looprange { first, count } => {
@@ -2593,14 +2591,14 @@ fn validate_openmp_obvious_scalar_constraints(
                 .transpose()?
                 .flatten();
             let upper = reject_obvious_nonpositive(upper_bound, span, "num_teams upper bound")?;
-            if let (Some(lower), Some(upper)) = (lower, upper) {
-                if lower > upper {
-                    return Err(Diagnostic::new(
-                        DiagnosticCode::InvalidClause,
-                        span,
-                        "num_teams lower bound must not exceed its upper bound",
-                    ));
-                }
+            if let (Some(lower), Some(upper)) = (lower, upper)
+                && lower > upper
+            {
+                return Err(Diagnostic::new(
+                    DiagnosticCode::InvalidClause,
+                    span,
+                    "num_teams lower bound must not exceed its upper bound",
+                ));
             }
         }
         ClauseData::ThreadLimit { limit } => {
@@ -2834,28 +2832,22 @@ fn validate_openmp_obvious_relations(
             .find(|clause| clause.kind() == kind)
             .map(crate::ast::OmpClause::payload)
     };
-    if let (
-        Some(ClauseData::Safelen { length: safe }),
-        Some(ClauseData::Simdlen { length: simd }),
-    ) = (
+    if let (Some(ClauseData::Safelen { length: safe }), Some(ClauseData::Simdlen { length: simd })) = (
         payload(OmpClauseKind::Safelen),
         payload(OmpClauseKind::Simdlen),
-    ) {
-        if let (
-            Some(IntegerEvaluation::NonNegative(safe)),
-            Some(IntegerEvaluation::NonNegative(simd)),
-        ) = (
-            obvious_integer_evaluation(safe),
-            obvious_integer_evaluation(simd),
-        ) {
-            if simd > safe {
-                return Err(Diagnostic::new(
-                    DiagnosticCode::InvalidClause,
-                    span,
-                    "simdlen must be less than or equal to safelen",
-                ));
-            }
-        }
+    ) && let (
+        Some(IntegerEvaluation::NonNegative(safe)),
+        Some(IntegerEvaluation::NonNegative(simd)),
+    ) = (
+        obvious_integer_evaluation(safe),
+        obvious_integer_evaluation(simd),
+    ) && simd > safe
+    {
+        return Err(Diagnostic::new(
+            DiagnosticCode::InvalidClause,
+            span,
+            "simdlen must be less than or equal to safelen",
+        ));
     }
     if let (
         Some(ClauseData::Collapse { n: collapsed }),
@@ -2863,22 +2855,19 @@ fn validate_openmp_obvious_relations(
     ) = (
         payload(OmpClauseKind::Collapse),
         payload(OmpClauseKind::Ordered),
-    ) {
-        if let (
-            Some(IntegerEvaluation::NonNegative(collapsed)),
-            Some(IntegerEvaluation::NonNegative(ordered)),
-        ) = (
-            obvious_integer_evaluation(collapsed),
-            obvious_integer_evaluation(ordered),
-        ) {
-            if ordered < collapsed {
-                return Err(Diagnostic::new(
-                    DiagnosticCode::InvalidClause,
-                    span,
-                    "ordered(n) must be greater than or equal to collapse(n)",
-                ));
-            }
-        }
+    ) && let (
+        Some(IntegerEvaluation::NonNegative(collapsed)),
+        Some(IntegerEvaluation::NonNegative(ordered)),
+    ) = (
+        obvious_integer_evaluation(collapsed),
+        obvious_integer_evaluation(ordered),
+    ) && ordered < collapsed
+    {
+        return Err(Diagnostic::new(
+            DiagnosticCode::InvalidClause,
+            span,
+            "ordered(n) must be greater than or equal to collapse(n)",
+        ));
     }
     Ok(())
 }
@@ -3041,14 +3030,14 @@ fn require_openmp_clause_semantic_facts(
                                 require_positive_constant_integer(upper, site, span, facts)
                             })
                             .transpose()?;
-                        if let (Some(lower), Some(upper)) = (lower_value, upper_value) {
-                            if lower > upper {
-                                return Err(Diagnostic::new(
-                                    DiagnosticCode::InvalidClause,
-                                    span,
-                                    "adjust_args range lower bound must not exceed its upper bound",
-                                ));
-                            }
+                        if let (Some(lower), Some(upper)) = (lower_value, upper_value)
+                            && lower > upper
+                        {
+                            return Err(Diagnostic::new(
+                                DiagnosticCode::InvalidClause,
+                                span,
+                                "adjust_args range lower bound must not exceed its upper bound",
+                            ));
                         }
                     }
                 }
@@ -3132,14 +3121,14 @@ fn require_openmp_clause_semantic_facts(
                         DiagnosticCode::MissingSemanticFact,
                         span,
                         "detach requires an encountering-final-task fact",
-                    ))
+                    ));
                 }
                 Some(true) => {
                     return Err(Diagnostic::new(
                         DiagnosticCode::InvalidAssociation,
                         span,
                         "a detach clause may not be encountered by a final task",
-                    ))
+                    ));
                 }
                 Some(false) => {}
             }
@@ -3159,17 +3148,17 @@ fn require_openmp_clause_semantic_facts(
                         DiagnosticCode::MissingSemanticFact,
                         span,
                         "a doacross vector requires the associated ordered(n) parameter fact",
-                    ))
+                    ));
                 }
                 Some(dimensions) if dimensions != vector.len() => {
                     return Err(Diagnostic::new(
                         DiagnosticCode::InvalidAssociation,
                         span,
                         format!(
-                        "doacross vector has {} dimensions but associated ordered has {dimensions}",
-                        vector.len()
-                    ),
-                    ))
+                            "doacross vector has {} dimensions but associated ordered has {dimensions}",
+                            vector.len()
+                        ),
+                    ));
                 }
                 Some(_) => {}
             }
@@ -3463,14 +3452,14 @@ fn require_openmp_clause_semantic_facts(
                                 DiagnosticCode::MissingSemanticFact,
                                 span,
                                 "num_teams bounds require a lower-not-greater-than-upper fact",
-                            ))
+                            ));
                         }
                         Some(false) => {
                             return Err(Diagnostic::new(
                                 DiagnosticCode::InvalidClause,
                                 span,
                                 "num_teams lower bound must not exceed its upper bound",
-                            ))
+                            ));
                         }
                         Some(true) => {}
                     }
@@ -3546,14 +3535,14 @@ fn require_openmp_clause_semantic_facts(
                             DiagnosticCode::MissingSemanticFact,
                             span,
                             "message requires a string-expression type fact",
-                        ))
+                        ));
                     }
                     Some(false) => {
                         return Err(Diagnostic::new(
                             DiagnosticCode::InvalidExpressionType,
                             span,
                             "message requires an expression of string OpenMP type",
-                        ))
+                        ));
                     }
                     Some(true) => {}
                 }
@@ -3583,7 +3572,7 @@ fn require_openmp_clause_semantic_facts(
                             format!(
                                 "declare_target enter(automap: ...) item {index} requires an allocatable-item fact"
                             ),
-                        ))
+                        ));
                     }
                     Some(false) => {
                         return Err(Diagnostic::new(
@@ -3592,7 +3581,7 @@ fn require_openmp_clause_semantic_facts(
                             format!(
                                 "declare_target enter(automap: ...) item {index} is not allocatable"
                             ),
-                        ))
+                        ));
                     }
                     Some(true) => {}
                 }
@@ -3612,14 +3601,14 @@ fn require_openmp_clause_semantic_facts(
                             DiagnosticCode::MissingSemanticFact,
                             span,
                             format!("data-motion locator {index} requires an lvalue-category fact"),
-                        ))
+                        ));
                     }
                     Some(false) => {
                         return Err(Diagnostic::new(
                             DiagnosticCode::InvalidLocator,
                             span,
                             format!("data-motion locator {index} is not an lvalue"),
-                        ))
+                        ));
                     }
                     Some(true) => {}
                 }

--- a/tests/common_block_lists.rs
+++ b/tests/common_block_lists.rs
@@ -78,9 +78,11 @@ fn openmp_common_block_spelling_and_linear_restriction_are_hard_errors() {
     )
     .expect("valid C OpenMP profile")
     .parser();
-    assert!(c_parser
-        .parse("#pragma omp parallel private(/block/)")
-        .is_err());
+    assert!(
+        c_parser
+            .parse("#pragma omp parallel private(/block/)")
+            .is_err()
+    );
 }
 
 #[test]

--- a/tests/delimiter_hardening.rs
+++ b/tests/delimiter_hardening.rs
@@ -104,9 +104,11 @@ fn braced_initializers_ignore_braces_inside_string_literals() {
 
 #[test]
 fn uses_allocators_traits_reject_non_variable_expressions() {
-    assert!(parser()
-        .parse("#pragma omp target uses_allocators(traits(f(\")\")): my_allocator)")
-        .is_err());
+    assert!(
+        parser()
+            .parse("#pragma omp target uses_allocators(traits(f(\")\")): my_allocator)")
+            .is_err()
+    );
 }
 
 #[test]

--- a/tests/feature_availability.rs
+++ b/tests/feature_availability.rs
@@ -162,8 +162,7 @@ fn openmp_uses_allocators_preserves_history_and_versions_new_forms() {
     assert_omp_accepted(OpenMpVersion::V5_0, historical);
     assert_omp_accepted(OpenMpVersion::V6_0, historical);
 
-    let modifier_form =
-        "#pragma omp target uses_allocators(traits(my_traits), memspace(omp_high_bw_mem_space): my_alloc)";
+    let modifier_form = "#pragma omp target uses_allocators(traits(my_traits), memspace(omp_high_bw_mem_space): my_alloc)";
     assert_omp_rejected(OpenMpVersion::V5_1, modifier_form);
     assert_omp_accepted(OpenMpVersion::V5_2, modifier_form);
 
@@ -174,11 +173,13 @@ fn openmp_uses_allocators_preserves_history_and_versions_new_forms() {
     let directive_modifier =
         "#pragma omp target uses_allocators(target, traits(my_traits): my_alloc)";
     for version in [OpenMpVersion::V5_2, OpenMpVersion::V6_0] {
-        assert!(OpenMpConfig::exact(version, c23(), SourceForm::Pragma)
-            .unwrap()
-            .parser()
-            .parse(directive_modifier)
-            .is_err());
+        assert!(
+            OpenMpConfig::exact(version, c23(), SourceForm::Pragma)
+                .unwrap()
+                .parser()
+                .parse(directive_modifier)
+                .is_err()
+        );
     }
 }
 
@@ -286,11 +287,13 @@ fn typed_data_motion_and_declare_target_payloads_have_independent_floors() {
     let automap = "!$omp declare target enter(automap: value)";
     assert_fortran_omp_rejected(OpenMpVersion::V5_2, automap);
     assert_fortran_omp_accepted(OpenMpVersion::V6_0, automap);
-    assert!(OpenMpConfig::new(c23(), SourceForm::Pragma)
-        .unwrap()
-        .parser()
-        .parse("#pragma omp declare target enter(automap: value)")
-        .is_err());
+    assert!(
+        OpenMpConfig::new(c23(), SourceForm::Pragma)
+            .unwrap()
+            .parser()
+            .parse("#pragma omp declare target enter(automap: value)")
+            .is_err()
+    );
 }
 
 #[test]

--- a/tests/host_profile_gates.rs
+++ b/tests/host_profile_gates.rs
@@ -93,38 +93,50 @@ fn type_name_features_use_the_same_exact_profile() {
         TypeName::parse_with_profile("long long", HostLanguageProfile::C(CStandard::C99),).is_ok()
     );
 
-    assert!(TypeName::parse_with_profile(
-        "decltype(value)",
-        HostLanguageProfile::Cpp(CppStandard::Cpp98),
-    )
-    .is_err());
-    assert!(TypeName::parse_with_profile(
-        "decltype(value)",
-        HostLanguageProfile::Cpp(CppStandard::Cpp11),
-    )
-    .is_ok());
+    assert!(
+        TypeName::parse_with_profile(
+            "decltype(value)",
+            HostLanguageProfile::Cpp(CppStandard::Cpp98),
+        )
+        .is_err()
+    );
+    assert!(
+        TypeName::parse_with_profile(
+            "decltype(value)",
+            HostLanguageProfile::Cpp(CppStandard::Cpp11),
+        )
+        .is_ok()
+    );
 
-    assert!(TypeName::parse_with_profile(
-        "integer(kind=8)",
-        HostLanguageProfile::Fortran(FortranStandard::Fortran77),
-    )
-    .is_err());
-    assert!(TypeName::parse_with_profile(
-        "integer(kind=8)",
-        HostLanguageProfile::Fortran(FortranStandard::Fortran90),
-    )
-    .is_ok());
+    assert!(
+        TypeName::parse_with_profile(
+            "integer(kind=8)",
+            HostLanguageProfile::Fortran(FortranStandard::Fortran77),
+        )
+        .is_err()
+    );
+    assert!(
+        TypeName::parse_with_profile(
+            "integer(kind=8)",
+            HostLanguageProfile::Fortran(FortranStandard::Fortran90),
+        )
+        .is_ok()
+    );
 
-    assert!(TypeName::parse_with_profile(
-        "class(my_type)",
-        HostLanguageProfile::Fortran(FortranStandard::Fortran95),
-    )
-    .is_err());
-    assert!(TypeName::parse_with_profile(
-        "class(my_type)",
-        HostLanguageProfile::Fortran(FortranStandard::Fortran2003),
-    )
-    .is_ok());
+    assert!(
+        TypeName::parse_with_profile(
+            "class(my_type)",
+            HostLanguageProfile::Fortran(FortranStandard::Fortran95),
+        )
+        .is_err()
+    );
+    assert!(
+        TypeName::parse_with_profile(
+            "class(my_type)",
+            HostLanguageProfile::Fortran(FortranStandard::Fortran2003),
+        )
+        .is_ok()
+    );
 }
 
 fn assert_omp_payload_rejected_by_c_and_cpp(source: &str) {

--- a/tests/openmp_allocate_shapes.rs
+++ b/tests/openmp_allocate_shapes.rs
@@ -35,8 +35,7 @@ fn allocate_cumulative_grammars_have_one_typed_semantic_shape() {
         } if items.len() == 2
     ));
 
-    let historical_source =
-        "#pragma omp parallel private(first, second) allocate(flag ? first_allocator : second_allocator: first, second)";
+    let historical_source = "#pragma omp parallel private(first, second) allocate(flag ? first_allocator : second_allocator: first, second)";
     for version in [OpenMpVersion::V5_0, OpenMpVersion::V6_0] {
         let historical = parse_c(version, historical_source)
             .unwrap_or_else(|error| panic!("historical allocate rejected in {version}: {error}"));
@@ -52,8 +51,7 @@ fn allocate_cumulative_grammars_have_one_typed_semantic_shape() {
         ));
     }
 
-    let modern_source =
-        "#pragma omp parallel private(first, second) allocate(align(64), allocator(make_allocator(device)): first, second)";
+    let modern_source = "#pragma omp parallel private(first, second) allocate(align(64), allocator(make_allocator(device)): first, second)";
     let error = parse_c(OpenMpVersion::V5_0, modern_source)
         .expect_err("complex allocate modifiers did not exist in OpenMP 5.0");
     assert_eq!(

--- a/tests/openmp_context_selectors.rs
+++ b/tests/openmp_context_selectors.rs
@@ -6,8 +6,8 @@ use roup::ast::{
 use roup::diagnostic::{Diagnostic, DiagnosticCode};
 use roup::ir::{ClauseData, MemoryOrder, RequireModifier};
 use roup::validation::{
-    validate_openmp_with_facts, IntegerEvaluation, LogicalEvaluation, OmpClauseSite,
-    OmpExpressionSite, SemanticFacts,
+    IntegerEvaluation, LogicalEvaluation, OmpClauseSite, OmpExpressionSite, SemanticFacts,
+    validate_openmp_with_facts,
 };
 use roup::version::{CStandard, HostLanguageProfile, OpenMpVersion, SourceForm, VersionPolicy};
 
@@ -210,11 +210,13 @@ fn scored_user_conditions_remain_cumulative_and_openmp_5_0_remains_static() {
     )
     .expect("OpenMP 5.1 permits a dynamic scored user condition");
 
-    assert!(parse(
-        OpenMpVersion::V6_0,
-        "#pragma omp metadirective when(user={condition(score(-1): runtime_flag)}: parallel)"
-    )
-    .is_err());
+    assert!(
+        parse(
+            OpenMpVersion::V6_0,
+            "#pragma omp metadirective when(user={condition(score(-1): runtime_flag)}: parallel)"
+        )
+        .is_err()
+    );
 }
 
 #[test]
@@ -311,11 +313,13 @@ fn extension_properties_are_recursive_and_user_maps_to_the_dynamic_context_witho
     )
     .expect("recursive extension and user facts");
 
-    assert!(parse(
-        OpenMpVersion::V6_0,
-        "#pragma omp metadirective when(dynamic={condition(runtime_flag)}: parallel)"
-    )
-    .is_err());
+    assert!(
+        parse(
+            OpenMpVersion::V6_0,
+            "#pragma omp metadirective when(dynamic={condition(runtime_flag)}: parallel)"
+        )
+        .is_err()
+    );
 }
 
 #[test]
@@ -356,6 +360,9 @@ fn device_number_requires_integer_and_conforming_device_facts() {
         "#pragma omp metadirective when(device={vendor_trait(nested(foo) junk)}: parallel)",
         "#pragma omp metadirective when(implementation={vendor_trait(score(2): nested(foo)}: parallel)",
     ] {
-        assert!(parse(OpenMpVersion::V6_0, invalid).is_err(), "accepted {invalid}");
+        assert!(
+            parse(OpenMpVersion::V6_0, invalid).is_err(),
+            "accepted {invalid}"
+        );
     }
 }

--- a/tests/openmp_loop_transformations.rs
+++ b/tests/openmp_loop_transformations.rs
@@ -68,12 +68,16 @@ fn standardized_loop_transformations_parse_through_the_public_api() {
 
 #[test]
 fn transformation_version_floors_and_payload_errors_are_strict() {
-    assert!(parser(OpenMpVersion::V5_0)
-        .parse("#pragma omp tile sizes(4)")
-        .is_err());
-    assert!(parser(OpenMpVersion::V5_2)
-        .parse("#pragma omp fuse")
-        .is_err());
+    assert!(
+        parser(OpenMpVersion::V5_0)
+            .parse("#pragma omp tile sizes(4)")
+            .is_err()
+    );
+    assert!(
+        parser(OpenMpVersion::V5_2)
+            .parse("#pragma omp fuse")
+            .is_err()
+    );
 
     for source in [
         "#pragma omp tile sizes()",

--- a/tests/openmp_numeric_and_default_shapes.rs
+++ b/tests/openmp_numeric_and_default_shapes.rs
@@ -62,11 +62,13 @@ fn num_threads_is_a_typed_positive_list_with_strict_prescriptiveness() {
         ClauseData::NumThreads { strict: true, nthreads }
             if nthreads.len() == 2
     ));
-    assert!(c_exact(
-        OpenMpVersion::V5_2,
-        "#pragma omp parallel num_threads(outer, inner)",
-    )
-    .is_err());
+    assert!(
+        c_exact(
+            OpenMpVersion::V5_2,
+            "#pragma omp parallel num_threads(outer, inner)",
+        )
+        .is_err()
+    );
     c_exact(
         OpenMpVersion::V6_0,
         "#pragma omp parallel num_threads(outer, inner)",
@@ -121,11 +123,13 @@ fn default_variable_categories_are_typed_and_host_gated() {
             kind: DefaultKind::Private,
         }
     ));
-    assert!(c_exact(
-        OpenMpVersion::V5_2,
-        "#pragma omp target default(scalar: private)",
-    )
-    .is_err());
+    assert!(
+        c_exact(
+            OpenMpVersion::V5_2,
+            "#pragma omp target default(scalar: private)",
+        )
+        .is_err()
+    );
     c_exact(
         OpenMpVersion::V6_0,
         "#pragma omp target default(scalar: private)",
@@ -170,11 +174,13 @@ fn linear_cumulative_grammars_canonicalize_without_losing_provenance() {
             ..
         }
     ));
-    assert!(c_exact(
-        OpenMpVersion::V5_1,
-        "#pragma omp declare simd linear(x: step(2), val)",
-    )
-    .is_err());
+    assert!(
+        c_exact(
+            OpenMpVersion::V5_1,
+            "#pragma omp declare simd linear(x: step(2), val)",
+        )
+        .is_err()
+    );
     c_exact(
         OpenMpVersion::V5_2,
         "#pragma omp declare simd linear(x: step(2), val)",

--- a/tests/openmp_reduction_declarations.rs
+++ b/tests/openmp_reduction_declarations.rs
@@ -303,7 +303,10 @@ fn induction_identifiers_accept_cpp_ids_and_only_fortran_defined_operators() {
         else {
             panic!("expected typed declare-induction parameter");
         };
-        assert!(matches!(induction.identifier(), OmpInductionIdentifier::Name(_)));
+        assert!(matches!(
+            induction.identifier(),
+            OmpInductionIdentifier::Name(_)
+        ));
         assert!(parsed.directive().clauses().iter().any(|clause| matches!(
             clause.payload(),
             ClauseData::Inductor {
@@ -338,16 +341,18 @@ fn induction_identifiers_accept_cpp_ids_and_only_fortran_defined_operators() {
         "!$omp declare_induction(.advance. : integer) inductor(advance_value(omp_var, omp_step)) collector(omp_step * omp_idx)",
     )
     .expect("Fortran inductor subroutine reference must parse");
-    assert!(procedure
-        .directive()
-        .clauses()
-        .iter()
-        .any(|clause| matches!(
-            clause.payload(),
-            ClauseData::Inductor {
-                expression: OmpInductorExpression::FortranSubroutineCall(_)
-            }
-        )));
+    assert!(
+        procedure
+            .directive()
+            .clauses()
+            .iter()
+            .any(|clause| matches!(
+                clause.payload(),
+                ClauseData::Inductor {
+                    expression: OmpInductorExpression::FortranSubroutineCall(_)
+                }
+            ))
+    );
 
     assert!(
         fortran(

--- a/tests/strict_clause_payloads.rs
+++ b/tests/strict_clause_payloads.rs
@@ -74,7 +74,10 @@ fn every_standardized_uses_allocators_shape_is_typed() {
         "#pragma omp target uses_allocators(traits(custom_traits), memspace(omp_high_bw_mem_space): custom_allocator)",
         "#pragma omp target uses_allocators(first_allocator; second_allocator)",
     ] {
-        assert!(omp(source).is_ok(), "rejected standardized syntax {source:?}");
+        assert!(
+            omp(source).is_ok(),
+            "rejected standardized syntax {source:?}"
+        );
     }
 }
 
@@ -120,22 +123,30 @@ fn standardized_selector_spelling_still_builds_typed_data() {
     else {
         panic!("expected typed metadirective selector");
     };
-    assert!(selector
-        .entries()
-        .iter()
-        .any(|entry| matches!(entry, OmpSelectorEntry::Device { .. })));
-    assert!(selector
-        .entries()
-        .iter()
-        .any(|entry| matches!(entry, OmpSelectorEntry::Implementation { .. })));
-    assert!(selector
-        .entries()
-        .iter()
-        .any(|entry| matches!(entry, OmpSelectorEntry::User { .. })));
-    assert!(selector
-        .entries()
-        .iter()
-        .any(|entry| matches!(entry, OmpSelectorEntry::Construct { .. })));
+    assert!(
+        selector
+            .entries()
+            .iter()
+            .any(|entry| matches!(entry, OmpSelectorEntry::Device { .. }))
+    );
+    assert!(
+        selector
+            .entries()
+            .iter()
+            .any(|entry| matches!(entry, OmpSelectorEntry::Implementation { .. }))
+    );
+    assert!(
+        selector
+            .entries()
+            .iter()
+            .any(|entry| matches!(entry, OmpSelectorEntry::User { .. }))
+    );
+    assert!(
+        selector
+            .entries()
+            .iter()
+            .any(|entry| matches!(entry, OmpSelectorEntry::Construct { .. }))
+    );
     assert!(selector.nested_directive().is_some());
 }
 

--- a/tests/strict_error_regressions.rs
+++ b/tests/strict_error_regressions.rs
@@ -58,9 +58,11 @@ fn device_accepts_ternary_expression_colon() {
 fn if_modifier_disambiguation_preserves_ternary_expressions() {
     let ternary = omp("#pragma omp parallel if(flag ? enabled : disabled)")
         .expect("a ternary colon is part of the host expression");
-    assert!(ternary.directive().clauses()[0]
-        .directive_name_modifier()
-        .is_none());
+    assert!(
+        ternary.directive().clauses()[0]
+            .directive_name_modifier()
+            .is_none()
+    );
 
     let modified = omp("#pragma omp target parallel if(target: enabled)")
         .expect("a real directive-name modifier must remain typed");


### PR DESCRIPTION
## Summary

This PR completes the repository's move to GitHub Actions-managed Pages deployment, refreshes every parent CI runner and action reference, updates the Rust dependency graph, migrates both workspace crates to the Rust 2024 edition, and reconciles the maintained documentation with the recent strict typed-AST/C-ABI refactor.

## CI and Pages deployment

- Run Linux jobs on the official `ubuntu-26.04` preview image and Rust matrix jobs on `macos-26`; retain Windows 2025.
- Keep the current published action majors: `actions/checkout@v7`, `actions/configure-pages@v6`, `actions/upload-pages-artifact@v5`, and `actions/deploy-pages@v5`.
- Build documentation on every CI event, but configure and upload the Pages artifact only for pushes to `main`.
- Deploy the `github-pages` artifact through the protected `github-pages` environment with explicit `actions: read`, `contents: read`, `pages: write`, and `id-token: write` permissions.
- Guard live Pages API/deployment steps during local `act` runs.
- Move the post-CI review workflow to Ubuntu 26.04, resolve empty fork-PR payloads through the workflow head SHA, and hard-fail when PR identity is missing or ambiguous or the required token is absent.
- No LLVM apt repository is used by the parent workflows, so no Resolute repository rewrite is required.

## Rust modernization

- Refresh all compatible transitive dependencies in `Cargo.lock`; direct dependencies (`nom`, `once_cell`, and `criterion`) were already at their latest releases.
- Retain the repository MSRV at Rust 1.88 because required mdBook 0.5.4 is the highest-minimum component in the complete dependency/tooling graph.
- Migrate both `roup` and `roup-capi` from edition 2021 to edition 2024.
- Use edition-2024 macro expression semantics instead of compatibility fragments.
- Convert C exports to explicit `#[unsafe(no_mangle)]` attributes, adopt 2024 match ergonomics and let chains, and apply Rust 2024 formatting.
- Preserve the C ABI service's pre-migration mutex-guard drop ordering explicitly before returning a result.
- Keep the safe parser crate independent of the optional C ABI and leave submodule revisions unchanged.

## Documentation cleanup

- Document the Pages artifact/deployment flow and the absence of a generated `gh-pages` branch.
- Correct the OpenMP compatibility audit to describe issues now fixed by the typed frontend and update the exhaustive C ABI clause count.
- Document dialect-aware OpenACC/OpenMP continuation handling and its hard-error behavior.
- Add the missing historical OpenMP and OpenACC continuation regression references.
- Clarify that versioned release notes describe historical APIs and that current README/book/header content is authoritative.
- Document Rust 2024, the repository-wide Rust 1.88 MSRV, and the current CI runner matrix.

## Impact

Pages publication now matches the repository's GitHub Actions Pages setting and remains isolated to successful pushes on `main`. The Rust and C ABI public surfaces remain covered by the existing strict tests; the edition migration changes implementation syntax and formatting without changing exported C symbols or parser semantics.

## Validation

- `./test_rust_versions.sh` — Rust 1.88 and current stable; formatting, safety audit, locked checks, Clippy with warnings denied, tests, and benches.
- `PATH=/tmp/roup-mdbook-0.5.4/bin:$PATH ./test.sh` — package verification, Rustdoc, mdBook, C ABI/header, 25 ompparser adapter tests, 8 accparser adapter tests, and C/C++/Fortran examples.
- Reproduced the combined Pages payload locally and archived it using the Pages artifact tar constraints; verified the book, Rust API docs, CNAME, and absence of symlinks/hard links.
- `cargo update --dry-run --verbose` — zero remaining compatible updates.
- `actionlint 1.7.12` with only its stale unknown-`ubuntu-26.04` label diagnostic excluded; GitHub's runner-images repository lists that requested label officially.
- `act -l` and `git diff --check`.
